### PR TITLE
Phase 2: kernel correctness (signal pipeline + process cleanup)

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -114,6 +114,12 @@ pub extern "C" fn kernel_main(boot_info: &'static BootInfo) -> ! {
         tty::vt::init();
     }
 
+    // Initialize VDSO trampoline page (used by signal sigreturn).
+    // SAFETY: heap and phys allocator are initialised.
+    unsafe {
+        crate::mm::vdso::init().expect("Failed to initialise VDSO");
+    }
+
     // Initialize drivers (subsystem, block, PCI).
     drivers::init();
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -6,3 +6,4 @@
 pub mod phys;
 pub mod virt;
 pub mod heap;
+pub mod vdso;

--- a/kernel/src/mm/vdso.rs
+++ b/kernel/src/mm/vdso.rs
@@ -1,0 +1,67 @@
+// VDSO: one user-mode page containing kernel-provided trampolines.
+//
+// Currently hosts a single trampoline used as the return address for user
+// signal handlers:
+//
+//     mov rax, 28       ; SYS_sigreturn
+//     syscall
+//
+// When a signal handler `ret`s, RIP lands on the first byte of this page
+// and the syscall executes, which restores the saved user context via
+// sys_sigreturn.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use crate::mm::phys::{self, FRAME_SIZE};
+
+/// Fixed user-virtual address where every process maps the VDSO page.
+///
+/// Chosen to sit just below the user/kernel split, well away from typical
+/// ELF segments and stack placement.
+pub const VDSO_VADDR: u64 = 0x0000_7FFF_FFFE_F000;
+
+/// Physical frame backing the VDSO page. Set once at boot by `init()`.
+static VDSO_PHYS: AtomicU64 = AtomicU64::new(0);
+
+/// Trampoline bytes:
+///   48 c7 c0 1c 00 00 00    mov rax, 0x1c    ; SYS_sigreturn (28)
+///   0f 05                   syscall
+///   f4                      hlt              ; safety net
+/// (10 bytes; remainder of the page is zero.)
+const TRAMPOLINE: [u8; 10] = [
+    0x48, 0xC7, 0xC0, 0x1C, 0x00, 0x00, 0x00,
+    0x0F, 0x05,
+    0xF4,
+];
+
+/// Initialise the VDSO. Allocates one frame, writes the trampoline, stores
+/// the physical address for later mapping into user page tables.
+///
+/// # Safety
+/// Must be called once at boot, after `mm::phys::init_from_memory_map` but
+/// before any user process is constructed.
+pub unsafe fn init() -> Result<(), &'static str> {
+    let frame = phys::alloc_frame().map_err(|_| "VDSO frame allocation failed")?;
+    let phys_addr = frame.addr();
+
+    // Zero the page then write the trampoline at offset 0.
+    core::ptr::write_bytes(phys_addr as *mut u8, 0, FRAME_SIZE);
+    core::ptr::copy_nonoverlapping(
+        TRAMPOLINE.as_ptr(),
+        phys_addr as *mut u8,
+        TRAMPOLINE.len(),
+    );
+
+    VDSO_PHYS.store(phys_addr, Ordering::Release);
+    crate::serial::serial_println!(
+        "[  0.000180] RACORE: VDSO initialised at phys 0x{:X}, mapped @ 0x{:X}",
+        phys_addr,
+        VDSO_VADDR,
+    );
+    Ok(())
+}
+
+/// Physical frame address of the VDSO page. Zero before `init()`.
+pub fn page_phys() -> u64 {
+    VDSO_PHYS.load(Ordering::Acquire)
+}

--- a/kernel/src/mm/virt.rs
+++ b/kernel/src/mm/virt.rs
@@ -418,6 +418,29 @@ pub fn create_user_page_table() -> Result<u64, &'static str> {
             }
         }
     }
+
+    // Map the VDSO page (user-readable, user-executable) so user-space signal
+    // handlers can `ret` into the kernel-provided trampoline. The VDSO frame
+    // is set up once at boot by `mm::vdso::init()`.
+    let vdso_phys = crate::mm::vdso::page_phys();
+    if vdso_phys != 0 {
+        // USER_CODE = PRESENT | USER (no NO_EXECUTE): the trampoline must be
+        // executable from ring 3. Not WRITABLE — the page is RX-only.
+        let vdso_flags = flags::USER_CODE;
+        // SAFETY: `vdso_phys` was allocated and initialised by `vdso::init()`
+        // at boot; `new_pml4_phys` was just allocated by `alloc_page_table`
+        // and currently contains only kernel-shared entries.
+        unsafe {
+            map_range(
+                new_pml4_phys,
+                crate::mm::vdso::VDSO_VADDR,
+                vdso_phys,
+                FRAME_SIZE as u64,
+                vdso_flags,
+            )?;
+        }
+    }
+
     Ok(new_pml4_phys)
 }
 

--- a/kernel/src/syscall/dispatch.rs
+++ b/kernel/src/syscall/dispatch.rs
@@ -104,6 +104,21 @@ pub extern "C" fn syscall_dispatch(
     arg5: u64,
     arg6: u64,
 ) -> i64 {
+    // Latch the on-kernel-stack `SyscallFrame` pointer (which the entry
+    // asm just wrote to PER_CPU.current_syscall_frame) into the current
+    // task struct *before* any handler can re-enable interrupts and
+    // potentially trigger a context switch. After this, any code path
+    // (signal delivery, exception recovery) can find the frame via
+    // `scheduler::with_current_syscall_frame_mut(...)` without racing
+    // a concurrent syscall on the same CPU.
+    //
+    // SAFETY: interrupts are disabled on entry to syscall_dispatch
+    // (SFMASK clears IF on `syscall`), so PER_CPU is stable here.
+    unsafe {
+        let frame_ptr = super::entry::current_syscall_frame_ptr();
+        crate::task::scheduler::set_current_syscall_frame_ptr(frame_ptr);
+    }
+
     let result: SyscallResult = match nr {
         SYS_EXIT => {
             handlers::sys_exit(arg1 as i32);
@@ -194,6 +209,20 @@ pub extern "C" fn syscall_dispatch(
 
     // Deliver any pending signals before returning to user space.
     handlers::deliver_pending_signals();
+
+    // Drop the frame pointer from the task struct now that we're about
+    // to leave kernel mode. Defensive: PER_CPU is cleared by the entry
+    // asm immediately after we return, but the task field would persist
+    // until the next syscall otherwise.
+    //
+    // SAFETY: returning into the entry asm which keeps interrupts
+    // disabled until SYSRETQ — but we may still be running with IF=1
+    // here, so wrap in cli/sti to keep the clear race-free.
+    unsafe {
+        core::arch::asm!("cli", options(nomem, nostack));
+        crate::task::scheduler::clear_current_syscall_frame_ptr();
+        core::arch::asm!("sti", options(nomem, nostack));
+    }
 
     result_to_raw(result)
 }

--- a/kernel/src/syscall/entry.rs
+++ b/kernel/src/syscall/entry.rs
@@ -19,6 +19,41 @@
 
 use crate::arch::gdt;
 
+/// On-kernel-stack layout the syscall entry trampoline builds before
+/// dispatch and pops via `sysretq`. Mirrors the exact push order in the
+/// naked asm: lowest-address field (`saved_arg6`) corresponds to the
+/// last value pushed, highest-address field (`user_rsp`) to the first.
+///
+/// `repr(C)` is required because the layout is consumed from assembly
+/// (via offsets) and Rust code (via field access). Field order MUST stay
+/// in lock-step with the push sequence in `syscall_entry` — adding or
+/// removing a push without updating this struct will silently corrupt
+/// user state on `sysretq`.
+///
+/// Signal delivery (Task 9) mutates `user_rip`, `user_rflags`, `user_rsp`
+/// to redirect to a user signal handler.
+#[derive(Debug)]
+#[repr(C)]
+pub struct SyscallFrame {
+    /// Saved arg6 (R9 from the original userland register set). The
+    /// dispatcher reads this from the stack as its 7th C ABI argument.
+    pub saved_arg6: u64,
+    /// Callee-saved + caller-saved GPRs we preserved across dispatch.
+    /// Order matches the push sequence (last push first in memory).
+    pub r15: u64,
+    pub r14: u64,
+    pub r13: u64,
+    pub r12: u64,
+    pub rbx: u64,
+    pub rbp: u64,
+    /// User RIP saved by the CPU into RCX on `syscall`.
+    pub user_rip: u64,
+    /// User RFLAGS saved by the CPU into R11 on `syscall`.
+    pub user_rflags: u64,
+    /// User RSP captured by the trampoline from `gs:[0x08]`.
+    pub user_rsp: u64,
+}
+
 // MSR addresses
 const MSR_STAR: u32 = 0xC000_0081;
 const MSR_LSTAR: u32 = 0xC000_0082;
@@ -108,6 +143,14 @@ unsafe extern "C" fn syscall_entry() {
         //   R9  = arg5 (currently in R8)
         //   [stack] = arg6 (currently in R9)
         "push r9",                          // arg6 on stack
+
+        // Publish a pointer to the on-stack SyscallFrame so that
+        // signal-delivery code in syscall_dispatch can mutate the
+        // user RIP/RSP/RFLAGS the trampoline is about to pop on
+        // sysretq. RSP now points at saved_arg6 (offset 0 of the
+        // SyscallFrame).
+        "mov gs:[0x10], rsp",
+
         "mov r9, r8",                       // arg5
         "mov r8, r10",                      // arg4
         "mov rcx, rdx",                     // arg3
@@ -117,6 +160,11 @@ unsafe extern "C" fn syscall_entry() {
 
         // Call Rust dispatcher
         "call {dispatch}",
+
+        // Clear the frame pointer now that dispatch has returned.
+        // Use an immediate-to-memory store so RAX (return value) is
+        // preserved.
+        "mov qword ptr gs:[0x10], 0",
 
         // RAX now contains the return value
         "add rsp, 8",                       // Pop arg6
@@ -156,17 +204,44 @@ unsafe extern "C" fn syscall_entry() {
 }
 
 /// Per-CPU data structure (minimal, UP only for MVP).
-/// At GS:0x00 = kernel RSP, GS:0x08 = user RSP (scratch).
+///
+/// Layout (offsets are fixed — referenced by the naked syscall asm via
+/// `gs:[offset]` and by the inline asm in `task::process`):
+///   - 0x00: `kernel_rsp`         — current task's kernel stack top
+///   - 0x08: `user_rsp`           — scratch slot to save user RSP on entry
+///   - 0x10: `current_syscall_frame` — pointer to the `SyscallFrame` the
+///       entry trampoline built on the kernel stack for the in-progress
+///       syscall. Set by the asm immediately before `call dispatch`,
+///       cleared after the dispatch returns. Read by `syscall_dispatch`
+///       to surface the frame to the rest of the kernel via the current
+///       task struct.
 #[repr(C, align(16))]
 pub(crate) struct PerCpuData {
     kernel_rsp: u64,
     user_rsp: u64,
+    current_syscall_frame: u64,
 }
 
 pub(crate) static mut PER_CPU: PerCpuData = PerCpuData {
     kernel_rsp: 0,
     user_rsp: 0,
+    current_syscall_frame: 0,
 };
+
+/// Read the per-CPU current-syscall-frame pointer set by the entry asm.
+///
+/// Returns 0 when not in a syscall (e.g., from an IRQ handler that
+/// preempted kernel-mode execution).
+///
+/// # Safety
+/// Must be called with interrupts disabled — otherwise a timer IRQ could
+/// context-switch between read and use, leaving the returned pointer
+/// dangling relative to the new task's kernel stack.
+#[inline]
+pub unsafe fn current_syscall_frame_ptr() -> u64 {
+    let per_cpu = &*core::ptr::addr_of!(PER_CPU);
+    per_cpu.current_syscall_frame
+}
 
 /// MSR for kernel GS base (used by SWAPGS).
 const MSR_KERNEL_GS_BASE: u32 = 0xC000_0102;

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -1573,6 +1573,7 @@ pub fn sys_fork() -> SyscallResult {
             cwd_len,
             in_signal_handler: false,
             saved_signal_frame_ptr: 0,
+            current_syscall_frame_ptr: 0,
         };
 
         match crate::task::scheduler::spawn_forked(child_task) {
@@ -1772,6 +1773,7 @@ pub fn sys_clone(flags: u32, stack: *mut u8, ptid: i32, tls: i32, ctid: *mut u8)
             cwd_len,
             in_signal_handler: false,
             saved_signal_frame_ptr: 0,
+            current_syscall_frame_ptr: 0,
         };
 
         match crate::task::scheduler::spawn_forked(child_task) {

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -391,11 +391,16 @@ pub fn deliver_pending_signals() {
         };
 
         // Lookup user handler for this signal (0 = SIG_DFL, 1 = SIG_IGN, else user fn).
+        // SAFETY: with_current_task_mut requires IF=0 so a timer IRQ cannot
+        // re-enter the scheduler while we hold &mut Task.
         let handler = unsafe {
-            crate::task::scheduler::with_current_task_mut(|t| {
+            core::arch::asm!("cli", options(nomem, nostack));
+            let h = crate::task::scheduler::with_current_task_mut(|t| {
                 t.signals.get_handler(sig as u8)
-            })
-        }.unwrap_or(SIG_DFL);
+            }).unwrap_or(SIG_DFL);
+            core::arch::asm!("sti", options(nomem, nostack));
+            h
+        };
 
         if handler == SIG_IGN {
             continue;
@@ -1972,6 +1977,20 @@ pub fn sys_sigaction(signum: i32, act: *const u8, oldact: *mut u8) -> SyscallRes
         // Set new action
         if !act.is_null() {
             let new_sa = &*(act as *const KSigAction);
+            // Reject non-canonical / kernel-range handler addresses. SYSRETQ to
+            // a non-canonical RIP raises #GP in kernel mode (Intel), so a
+            // malicious caller could otherwise crash the kernel via
+            // sigaction(sig, {handler = 0xDEAD_BEEF_DEAD_BEEF}) + kill(self, sig).
+            // SIG_DFL (0) and SIG_IGN (1) are allowed as special sentinels.
+            const USER_SPACE_TOP: u64 = 0x0000_8000_0000_0000;
+            let h = new_sa.handler;
+            if h != crate::task::signal::SIG_DFL
+                && h != crate::task::signal::SIG_IGN
+                && h >= USER_SPACE_TOP
+            {
+                core::arch::asm!("sti", options(nomem, nostack));
+                return Err(SyscallError::EINVAL);
+            }
             crate::task::scheduler::with_current_task_mut(|t| {
                 t.signals.set_handler(signum as u8, new_sa.handler);
             });
@@ -1999,10 +2018,19 @@ pub fn sys_sigreturn() -> SyscallResult {
     unsafe {
         core::arch::asm!("cli", options(nomem, nostack));
         let r = crate::task::scheduler::with_current_syscall_frame_mut(|task, frame| {
-            if !task.in_signal_handler || task.saved_signal_frame_ptr == 0 {
-                return Err(SyscallError::EFAULT);
-            }
-            let frame_ptr = task.saved_signal_frame_ptr;
+            // Find the SignalFrame on the user stack. The handler's `ret`
+            // popped the VDSO trampoline address that delivery had pushed, so
+            // at sigreturn entry the user RSP points exactly at the base of
+            // the active SignalFrame. Read from there rather than from
+            // task.saved_signal_frame_ptr — that way nested handlers each
+            // restore their own caller's context (the outer SignalFrame is
+            // higher up the stack and untouched by the inner sigreturn).
+            //
+            // No `in_signal_handler` check: a user calling sys_sigreturn
+            // without an active handler can only mutate its own register
+            // state, which user code can already do via plain instructions.
+            // validate_user_ptr below is the kernel-safety guarantee.
+            let frame_ptr = frame.user_rsp;
             let size = core::mem::size_of::<SignalFrame>();
             if validate_user_ptr(frame_ptr, size).is_err() {
                 return Err(SyscallError::EFAULT);
@@ -2027,10 +2055,14 @@ pub fn sys_sigreturn() -> SyscallResult {
             frame.user_rsp = sf.rsp;
             frame.user_rflags = sf.rflags;
 
-            // Restore signal mask.
+            // Restore signal mask. (Each SignalFrame captures the blocked-set
+            // as it was just before its own delivery, so this correctly nests:
+            // inner sigreturn restores the outer-handler-running mask; outer
+            // sigreturn then restores the pre-outer-delivery mask.)
             task.signals.blocked = sf.saved_sigmask as u32;
-            task.in_signal_handler = false;
-            task.saved_signal_frame_ptr = 0;
+            // task.in_signal_handler / saved_signal_frame_ptr are now legacy
+            // informational fields; we deliberately don't clear them — clearing
+            // on inner sigreturn would break a subsequent outer sigreturn.
 
             Ok(())
         });

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -1570,6 +1570,8 @@ pub fn sys_fork() -> SyscallResult {
             name_len,
             cwd,
             cwd_len,
+            in_signal_handler: false,
+            saved_signal_frame_ptr: 0,
         };
 
         match crate::task::scheduler::spawn_forked(child_task) {
@@ -1767,6 +1769,8 @@ pub fn sys_clone(flags: u32, stack: *mut u8, ptid: i32, tls: i32, ctid: *mut u8)
             name_len,
             cwd,
             cwd_len,
+            in_signal_handler: false,
+            saved_signal_frame_ptr: 0,
         };
 
         match crate::task::scheduler::spawn_forked(child_task) {

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -372,32 +372,121 @@ fn collect_user_argv(path: &str, argv_ptr: u64) -> Result<alloc::vec::Vec<alloc:
 /// Deliver any pending signals for the current task.
 /// Called at the end of every syscall before returning to user space.
 pub fn deliver_pending_signals() {
-    use crate::task::signal::SignalAction;
+    use crate::task::signal::{SignalAction, SignalFrame, SignalState, Signal, SIG_DFL, SIG_IGN};
+
     loop {
-        // SAFETY: disabling interrupts while accessing the scheduler.
-        let sig = unsafe {
-            core::arch::asm!("cli", options(nomem, nostack));
-            let s = crate::task::scheduler::take_pending_signal();
-            core::arch::asm!("sti", options(nomem, nostack));
-            s
-        };
-        let sig = match sig {
-            None => break,
-            Some(s) => s,
-        };
-        match crate::task::signal::SignalState::default_action(sig) {
-            SignalAction::Terminate => {
-                sys_exit(-1);
+        // Phase 1: decide what to do with the next pending signal.
+        let sig: Signal = {
+            // SAFETY: disabling interrupts while accessing the scheduler.
+            let s = unsafe {
+                core::arch::asm!("cli", options(nomem, nostack));
+                let s = crate::task::scheduler::take_pending_signal();
+                core::arch::asm!("sti", options(nomem, nostack));
+                s
+            };
+            match s {
+                None => return,
+                Some(s) => s,
             }
-            SignalAction::Ignore => {}
-            SignalAction::Stop => {
-                unsafe {
-                    core::arch::asm!("cli", options(nomem, nostack));
-                    crate::task::scheduler::block_and_reschedule();
+        };
+
+        // Lookup user handler for this signal (0 = SIG_DFL, 1 = SIG_IGN, else user fn).
+        let handler = unsafe {
+            crate::task::scheduler::with_current_task_mut(|t| {
+                t.signals.get_handler(sig as u8)
+            })
+        }.unwrap_or(SIG_DFL);
+
+        if handler == SIG_IGN {
+            continue;
+        }
+        if handler == SIG_DFL {
+            match SignalState::default_action(sig) {
+                SignalAction::Terminate => { sys_exit(-1); }
+                SignalAction::Ignore => { continue; }
+                SignalAction::Stop => {
+                    unsafe {
+                        core::arch::asm!("cli", options(nomem, nostack));
+                        crate::task::scheduler::block_and_reschedule();
+                    }
+                    continue;
                 }
+                SignalAction::Continue => { continue; }
             }
-            SignalAction::Continue => {
-                // Task is already running; nothing to do.
+        }
+
+        // Custom user handler — push SignalFrame and redirect.
+        let result: Option<Result<(), ()>> = unsafe {
+            core::arch::asm!("cli", options(nomem, nostack));
+            let r = crate::task::scheduler::with_current_syscall_frame_mut(|task, frame| {
+                // 1. Compute new user RSP: skip the red zone (128 bytes),
+                //    reserve space for SignalFrame, keep 16-byte alignment.
+                let red_zone = 128u64;
+                let frame_size = SignalFrame::aligned_size() as u64;
+                let mut new_rsp = frame.user_rsp.wrapping_sub(red_zone + frame_size);
+                new_rsp &= !0xF; // 16-byte align
+
+                // 2. Build the SignalFrame from the interrupted context.
+                //    Caller-saved GPRs (rax, rcx, rdx, rsi, rdi, r8, r10, r11)
+                //    were clobbered by the syscall ABI and aren't saved on the
+                //    SyscallFrame — fill them with zero so sigreturn restores 0
+                //    (matches "clobbered by syscall" semantics).
+                let sf = SignalFrame {
+                    rax: 0, rcx: 0, rdx: 0, rsi: 0, rdi: 0,
+                    r8: 0, r10: 0, r11: 0,
+                    rbx: frame.rbx, rbp: frame.rbp,
+                    r9: frame.saved_arg6,
+                    r12: frame.r12, r13: frame.r13, r14: frame.r14, r15: frame.r15,
+                    rip: frame.user_rip, rsp: frame.user_rsp, rflags: frame.user_rflags,
+                    saved_sigmask: task.signals.blocked as u64,
+                    signal_number: sig as u32,
+                    _pad: 0,
+                };
+
+                // 3. copy_to_user: write the frame to user stack.
+                //    validate_user_ptr is defined in this file (handlers.rs).
+                if validate_user_ptr(new_rsp, frame_size as usize).is_err() {
+                    return Err(());
+                }
+                core::ptr::write_volatile(new_rsp as *mut SignalFrame, sf);
+
+                // 4. Push the VDSO trampoline address as the handler's return
+                //    address. RSP -= 8.
+                let trampoline_rsp = new_rsp.wrapping_sub(8);
+                if validate_user_ptr(trampoline_rsp, 8).is_err() {
+                    return Err(());
+                }
+                *(trampoline_rsp as *mut u64) = crate::mm::vdso::VDSO_VADDR;
+
+                // 5. Patch the syscall frame: RIP = handler, RSP = trampoline_rsp.
+                //    NOTE: We cannot set RDI=signo on the SyscallFrame because RDI
+                //    is not stored there. We rely on the handler being declared
+                //    as `void handler(int signo)` and the dispatch path leaving
+                //    RDI = first dispatch arg (which after a sigaction call was
+                //    the signum). For ABI cleanliness, a stub trampoline page
+                //    could set RDI explicitly; that's a follow-up. For now,
+                //    handlers that test the signum may see undefined RDI — they
+                //    should still receive the correct *delivery* (handler runs).
+                // TODO: pass signum via RDI (extend SyscallFrame or VDSO trampoline).
+                frame.user_rip = handler;
+                frame.user_rsp = trampoline_rsp;
+
+                // 6. Record bookkeeping so sys_sigreturn can find the frame.
+                task.in_signal_handler = true;
+                task.saved_signal_frame_ptr = new_rsp;
+                // Block this signal during its own handler (POSIX default).
+                task.signals.blocked |= sig.mask();
+                Ok(())
+            });
+            core::arch::asm!("sti", options(nomem, nostack));
+            r
+        };
+
+        match result {
+            Some(Ok(())) => return,
+            _ => {
+                // Frame write failed (bad user pointer). Force-exit with SIGSEGV.
+                sys_exit(-1);
             }
         }
     }

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -411,11 +411,12 @@ pub fn sys_exit(status: i32) -> ! {
         crate::task::scheduler::current_pid()
     );
 
-    // Mark task as zombie and schedule away
-    // TODO: proper process cleanup (release address space, fds, signal parent)
+    // Address space + kernel stack are reclaimed by reap_zombie_child when
+    // the parent calls waitpid; FDs and parent SIGCHLD are handled in
+    // exit_current below.
     unsafe { crate::task::scheduler::exit_current(status); }
 
-    // Should not reach here — exit_current never returns
+    // exit_current never returns. Halt as a safety net.
     loop {
         unsafe { core::arch::asm!("cli; hlt", options(nomem, nostack)); }
     }

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -1986,10 +1986,57 @@ pub fn sys_sigaction(signum: i32, act: *const u8, oldact: *mut u8) -> SyscallRes
 // Syscall 28: sys_sigreturn
 // ─────────────────────────────────────────────────
 
-/// Return from a signal handler (restores pre-signal context).
-/// For now, this is a stub — signal delivery is default-action only.
+/// Return from a signal handler.
+///
+/// Invoked by the VDSO trampoline (`mov rax, 28; syscall`) after the user
+/// signal handler returns. Restores the pre-signal user context that was
+/// saved on the user stack by signal delivery (Task 9), clears the
+/// in-signal-handler bookkeeping, and returns. The normal syscall return
+/// path then sysrets into the restored user RIP/RSP/RFLAGS.
 pub fn sys_sigreturn() -> SyscallResult {
-    // TODO: restore saved user context from signal frame
+    use crate::task::signal::SignalFrame;
+
+    unsafe {
+        core::arch::asm!("cli", options(nomem, nostack));
+        let r = crate::task::scheduler::with_current_syscall_frame_mut(|task, frame| {
+            if !task.in_signal_handler || task.saved_signal_frame_ptr == 0 {
+                return Err(SyscallError::EFAULT);
+            }
+            let frame_ptr = task.saved_signal_frame_ptr;
+            let size = core::mem::size_of::<SignalFrame>();
+            if validate_user_ptr(frame_ptr, size).is_err() {
+                return Err(SyscallError::EFAULT);
+            }
+            // copy_from_user (kernel reads user memory).
+            let sf: SignalFrame = core::ptr::read_volatile(frame_ptr as *const SignalFrame);
+
+            // Restore the SyscallFrame fields we can. Caller-saved GPRs (rax,
+            // rcx, rdx, rsi, rdi, r8, r10, r11) are not stored on the
+            // SyscallFrame; they'll naturally come out of sysret as whatever
+            // the syscall-return path puts there (typically 0 / sigreturn's
+            // own return value).
+            frame.saved_arg6 = sf.r9;
+            frame.rbx = sf.rbx;
+            frame.rbp = sf.rbp;
+            frame.r12 = sf.r12;
+            frame.r13 = sf.r13;
+            frame.r14 = sf.r14;
+            frame.r15 = sf.r15;
+            // Restore interrupted context.
+            frame.user_rip = sf.rip;
+            frame.user_rsp = sf.rsp;
+            frame.user_rflags = sf.rflags;
+
+            // Restore signal mask.
+            task.signals.blocked = sf.saved_sigmask as u32;
+            task.in_signal_handler = false;
+            task.saved_signal_frame_ptr = 0;
+
+            Ok(())
+        });
+        core::arch::asm!("sti", options(nomem, nostack));
+        r.unwrap_or(Err(SyscallError::EFAULT))
+    }?;
     Ok(0)
 }
 

--- a/kernel/src/task/process.rs
+++ b/kernel/src/task/process.rs
@@ -287,6 +287,8 @@ impl UserProcess {
                 name_len: len,
                 cwd: cwd_buf,
                 cwd_len: 1,
+                in_signal_handler: false,
+                saved_signal_frame_ptr: 0,
             },
             user_entry: loaded.entry_point,
             user_stack_top: loaded.stack_virt_top,

--- a/kernel/src/task/process.rs
+++ b/kernel/src/task/process.rs
@@ -289,6 +289,7 @@ impl UserProcess {
                 cwd_len: 1,
                 in_signal_handler: false,
                 saved_signal_frame_ptr: 0,
+                current_syscall_frame_ptr: 0,
             },
             user_entry: loaded.entry_point,
             user_stack_top: loaded.stack_virt_top,

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -286,12 +286,17 @@ impl Scheduler {
         self.schedule();
     }
 
-    /// Terminate the current task, setting it to Zombie, then wake its parent.
+    /// Terminate the current task, setting it to Zombie, then wake its parent
+    /// and post SIGCHLD. Closes user-visible file descriptors early so pipes
+    /// and inodes see their refcount drop before the parent reaps.
     pub fn exit_current(&mut self, status: i32) {
         let idx = self.current;
         let (my_pid, parent_pid) = if let Some(ref mut task) = self.tasks[idx] {
             task.state = TaskState::Zombie;
             task.exit_status = status;
+            // Drop every file descriptor right now. The Arc<OpenFile> refs
+            // are released, which makes pipes/inodes observe the close.
+            task.fd_table.close_all();
             (task.pid, task.parent_pid)
         } else { (0, 0) };
 
@@ -305,19 +310,21 @@ impl Scheduler {
             }
         }
 
-        // Wake the parent if it is blocked waiting for a child.
+        // Notify the parent: post SIGCHLD and wake it if it was blocked.
         if parent_pid != 0 {
             for slot in self.tasks.iter_mut().flatten() {
-                if slot.pid == parent_pid && matches!(slot.state, TaskState::Blocked) {
-                    slot.state = TaskState::Ready;
+                if slot.pid == parent_pid {
+                    slot.signals.send(super::signal::Signal::SIGCHLD);
+                    if matches!(slot.state, TaskState::Blocked) {
+                        slot.state = TaskState::Ready;
+                    }
                     break;
                 }
             }
         }
 
-        // Schedule another task immediately
+        // Schedule another task immediately.
         self.schedule();
-        // If we get here (no other tasks), halt
     }
 
     fn child_matches_wait_filter(

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -904,6 +904,67 @@ where
     })
 }
 
+/// Stash the kernel-stack pointer to the in-progress `SyscallFrame` in
+/// the current task. Called from `syscall_dispatch` immediately after
+/// entry so that signal delivery (and other late-in-syscall code) can
+/// reach the frame via [`with_current_syscall_frame_mut`].
+///
+/// Safe to call with `ptr == 0` (e.g. from a non-syscall execution
+/// context that wants to clear the slot defensively).
+///
+/// # Safety
+/// Must be called with interrupts disabled. The caller is responsible
+/// for ensuring `ptr` points to a valid `SyscallFrame` on the current
+/// task's kernel stack that remains alive for the duration of any
+/// matching [`with_current_syscall_frame_mut`] call.
+pub unsafe fn set_current_syscall_frame_ptr(ptr: u64) {
+    if let Some(ref mut sched) = *core::ptr::addr_of_mut!(SCHEDULER) {
+        let idx = sched.current;
+        if let Some(ref mut t) = sched.tasks[idx] {
+            t.current_syscall_frame_ptr = ptr;
+        }
+    }
+}
+
+/// Drop the current task's syscall-frame pointer. Companion to
+/// [`set_current_syscall_frame_ptr`].
+///
+/// # Safety
+/// Must be called with interrupts disabled.
+pub unsafe fn clear_current_syscall_frame_ptr() {
+    set_current_syscall_frame_ptr(0);
+}
+
+/// Run a closure with mutable access to the current task's in-progress
+/// `SyscallFrame`. Returns `None` when no syscall is in flight on the
+/// current task (i.e. the pointer is null).
+///
+/// Used by signal delivery to overwrite `user_rip`/`user_rsp`/`user_rflags`
+/// so the syscall trampoline's `sysretq` lands in a user signal handler
+/// instead of the original interrupted instruction.
+///
+/// # Safety
+/// Must be called with interrupts disabled. The closure must not
+/// trigger a context switch on the current task — otherwise the
+/// reference it holds would dangle (the underlying memory lives on the
+/// current task's kernel stack, which is left unchanged by a switch but
+/// the `&mut` reference would alias once the task is rescheduled).
+pub unsafe fn with_current_syscall_frame_mut<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&mut super::task::Task, &mut crate::syscall::entry::SyscallFrame) -> R,
+{
+    (*core::ptr::addr_of_mut!(SCHEDULER)).as_mut().and_then(|s| {
+        let idx = s.current;
+        let task = s.tasks[idx].as_mut()?;
+        let ptr = task.current_syscall_frame_ptr;
+        if ptr == 0 {
+            return None;
+        }
+        let frame = &mut *(ptr as *mut crate::syscall::entry::SyscallFrame);
+        Some(f(task, frame))
+    })
+}
+
 /// Run a closure with read access to a task identified by PID.
 ///
 /// # Safety

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -528,6 +528,11 @@ impl Scheduler {
             task.kernel_stack_base = new_task.kernel_stack_base;
             task.page_table_phys = new_task.page_table_phys;
             task.signals = super::signal::SignalState::new();
+            // Drop signal-handler bookkeeping — the new image has none of the
+            // old image's user-space sigframes or in-flight handlers.
+            task.in_signal_handler = false;
+            task.saved_signal_frame_ptr = 0;
+            task.current_syscall_frame_ptr = 0;
             task.name = new_task.name;
             task.name_len = new_task.name_len;
         }

--- a/kernel/src/task/signal.rs
+++ b/kernel/src/task/signal.rs
@@ -151,3 +151,115 @@ pub enum SignalAction {
     Stop,
     Continue,
 }
+
+/// Frame written to the user stack when delivering a signal with a user
+/// handler. `sys_sigreturn` consumes it to restore the interrupted context.
+///
+/// Layout is `#[repr(C)]` because user-space VDSO code may read it.
+///
+/// Field order intentionally mirrors the order syscall/interrupt entry
+/// pushes general-purpose registers, then the interrupted instruction
+/// state, then signal bookkeeping. Sizes (with `#[repr(C)]`):
+///   - 15 × u64 GPRs                              = 120 bytes  (offsets   0..120)
+///   - rip, rsp, rflags  (3 × u64)                =  24 bytes  (offsets 120..144)
+///   - saved_sigmask     (u64)                    =   8 bytes  (offsets 144..152)
+///   - signal_number     (u32)                    =   4 bytes  (offsets 152..156)
+///   - _pad              (u32)                    =   4 bytes  (offsets 156..160)
+/// Total: 160 bytes, already 16-byte aligned.
+#[derive(Debug, Clone, Copy, Default)]
+#[repr(C)]
+pub struct SignalFrame {
+    // Saved GPRs in the order pushed by the syscall entry path
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    pub rbp: u64,
+    pub r8:  u64,
+    pub r9:  u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+    // Interrupted instruction state
+    pub rip: u64,
+    pub rsp: u64,
+    pub rflags: u64,
+    // Signal bookkeeping
+    pub saved_sigmask: u64,
+    pub signal_number: u32,
+    pub _pad: u32,
+}
+
+impl SignalFrame {
+    /// Total bytes a `SignalFrame` occupies on the user stack, rounded up
+    /// to 16 bytes so the C ABI's pre-`call` stack alignment guarantee is
+    /// satisfied when the kernel hands control to the user handler.
+    pub const fn aligned_size() -> usize {
+        (core::mem::size_of::<SignalFrame>() + 15) / 16 * 16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signal_frame_size_is_160() {
+        // 18 × u64 (GPRs + rip/rsp/rflags) + 1 × u64 (saved_sigmask)
+        //   + 1 × u32 (signal_number) + 1 × u32 (_pad) = 160 bytes.
+        assert_eq!(core::mem::size_of::<SignalFrame>(), 160);
+    }
+
+    #[test]
+    fn signal_frame_aligned_size_is_160() {
+        // 160 is already a multiple of 16, so aligned_size == size_of.
+        assert_eq!(SignalFrame::aligned_size(), 160);
+    }
+
+    #[test]
+    fn signal_frame_alignment_is_at_least_8() {
+        // `#[repr(C)]` on a struct whose largest field is u64 yields 8-byte
+        // alignment. The 16-byte runtime alignment is achieved by stack
+        // adjustment (see `aligned_size`), not by the struct itself.
+        assert_eq!(core::mem::align_of::<SignalFrame>(), 8);
+    }
+
+    #[test]
+    fn signal_frame_field_offsets() {
+        let f = SignalFrame::default();
+        let base = &f as *const SignalFrame as usize;
+        let off = |addr: usize| addr - base;
+
+        // GPR block: rax..r15 are 15 consecutive u64s starting at 0.
+        assert_eq!(off(&f.rax as *const u64 as usize), 0);
+        assert_eq!(off(&f.rbx as *const u64 as usize), 8);
+        assert_eq!(off(&f.r15 as *const u64 as usize), 14 * 8);
+
+        // Interrupted instruction state.
+        assert_eq!(off(&f.rip    as *const u64 as usize), 15 * 8); // 120
+        assert_eq!(off(&f.rsp    as *const u64 as usize), 16 * 8); // 128
+        assert_eq!(off(&f.rflags as *const u64 as usize), 17 * 8); // 136
+
+        // Signal bookkeeping.
+        assert_eq!(off(&f.saved_sigmask as *const u64 as usize), 18 * 8); // 144
+        assert_eq!(off(&f.signal_number as *const u32 as usize), 152);
+        assert_eq!(off(&f._pad          as *const u32 as usize), 156);
+    }
+
+    #[test]
+    fn signal_frame_default_is_zeroed() {
+        let f = SignalFrame::default();
+        assert_eq!(f.rax, 0);
+        assert_eq!(f.rip, 0);
+        assert_eq!(f.rsp, 0);
+        assert_eq!(f.rflags, 0);
+        assert_eq!(f.saved_sigmask, 0);
+        assert_eq!(f.signal_number, 0);
+        assert_eq!(f._pad, 0);
+    }
+}

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -122,6 +122,13 @@ pub struct Task {
     /// User-space pointer to the SignalFrame written for the currently
     /// active handler. Zero when no handler is running.
     pub saved_signal_frame_ptr: u64,
+    /// Kernel-space pointer to this task's currently-active `SyscallFrame`
+    /// on its kernel stack (the frame the syscall entry trampoline will
+    /// pop into user registers/RIP/RSP/RFLAGS on `sysretq`). Set by the
+    /// syscall entry path and cleared on the way out. Zero when the task
+    /// is not currently executing inside a syscall. Signal delivery code
+    /// dereferences this to redirect the return to a user handler.
+    pub current_syscall_frame_ptr: u64,
 }
 
 impl Task {
@@ -195,6 +202,7 @@ impl Task {
             cwd_len: 1,
             in_signal_handler: false,
             saved_signal_frame_ptr: 0,
+            current_syscall_frame_ptr: 0,
         })
     }
 
@@ -226,6 +234,7 @@ impl Task {
             cwd_len: 1,
             in_signal_handler: false,
             saved_signal_frame_ptr: 0,
+            current_syscall_frame_ptr: 0,
         }
     }
 }

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -116,6 +116,12 @@ pub struct Task {
     /// Current working directory (absolute path, no trailing slash except root).
     pub cwd: [u8; 256],
     pub cwd_len: usize,
+    /// True between the moment a signal handler is invoked and the moment
+    /// `sys_sigreturn` runs. Used by sigreturn to validate state.
+    pub in_signal_handler: bool,
+    /// User-space pointer to the SignalFrame written for the currently
+    /// active handler. Zero when no handler is running.
+    pub saved_signal_frame_ptr: u64,
 }
 
 impl Task {
@@ -187,6 +193,8 @@ impl Task {
             name_len: len,
             cwd: cwd_buf,
             cwd_len: 1,
+            in_signal_handler: false,
+            saved_signal_frame_ptr: 0,
         })
     }
 
@@ -216,6 +224,8 @@ impl Task {
             name_len: 4,
             cwd: cwd_buf,
             cwd_len: 1,
+            in_signal_handler: false,
+            saved_signal_frame_ptr: 0,
         }
     }
 }

--- a/kernel/src/vfs/file.rs
+++ b/kernel/src/vfs/file.rs
@@ -132,6 +132,14 @@ impl FdTable {
         Ok(())
     }
 
+    /// Close every open descriptor. Each `OpenFile` Arc is dropped; pipes and
+    /// inodes see their refcount drop, so consumers observe EOF promptly.
+    pub fn close_all(&mut self) {
+        for slot in self.entries.iter_mut() {
+            *slot = None;
+        }
+    }
+
     /// Duplicate a fd.
     pub fn dup(&mut self, oldfd: i32) -> VfsResult<i32> {
         let file = self.get(oldfd)?;


### PR DESCRIPTION
## Summary

Closes two critical correctness TODOs in the kernel:
- **#4 process cleanup** (`handlers.rs:415`): `sys_exit`/`exit_current` now closes the exiting task's file descriptors immediately (so pipes/inodes see EOF before the parent reaps) and posts `SIGCHLD` to the parent alongside the existing wake-from-blocked path. Page table + kernel stack release stays in `reap_zombie_child_filtered` as before.
- **#7 sigreturn** (`handlers.rs:1896`): full user-handler signal-delivery pipeline. New `SignalFrame` struct + VDSO trampoline page + `with_current_syscall_frame_mut` accessor + rewritten `deliver_pending_signals` + implemented `sys_sigreturn`.

## Pipeline overview

1. **Delivery** (`deliver_pending_signals` after every syscall): if a non-default user handler is registered, the kernel pushes a `SignalFrame` onto the user stack (respecting the 128-byte red zone, 16-byte aligned), pushes the VDSO trampoline address as the handler's return address, sets `frame.user_rip = handler` / `frame.user_rsp = trampoline_rsp`, blocks the signal during its own handler, and lets sysret carry control into the handler.
2. **Handler runs in user space.** When it `ret`s, RIP lands on the VDSO trampoline page mapped at `0x0000_7FFF_FFFE_F000`.
3. **VDSO trampoline** is `mov rax, 28; syscall; hlt` — 10 bytes, RX-only.
4. **`sys_sigreturn`** reads the `SignalFrame` from `frame.user_rsp` (which the handler's `ret` left exactly at the frame base), restores the saved registers/RIP/RSP/RFLAGS/sigmask, and returns. The normal syscall-return path then sysrets into the restored user context.

Nested handlers work naturally: the inner sigreturn reads its own SignalFrame off the inner RSP and restores the still-running outer handler; the outer sigreturn then walks up to the pre-outer-delivery context.

## Out of scope (Phase 2.1)

Integration tests (`tests/integration/signal_roundtrip.rs`, `tests/integration/exec_loop.rs`) and the `integration-smoke` CI job were planned as Tasks 11-13 but deferred. They require:
- libc-lite syscall wrappers (`sigaction`, `kill`, `getpid`, `fork`, `execve`, `waitpid`)
- Workspace crate setup for the test binaries
- `init` feature-flag wiring to run them at boot
- `scripts/build-image.sh` changes to stage them into initramfs
- A new `sys_getfreepages` debug syscall for the exec-loop test
- QEMU + OVMF runtime to validate

The kernel-side primitives are all in place to unblock that work.

## Post-implementation review fixes

Four issues caught by a final review, fixed in `0e0f27f`:
1. `deliver_pending_signals` called `with_current_task_mut` with IF=1, risking timer-IRQ scheduler reentry. Now wrapped in cli/sti.
2. `sys_sigreturn` now reads SignalFrame ptr from `frame.user_rsp` (the only path that supports nested signals); dropped the `in_signal_handler` precondition (relied on `validate_user_ptr` for kernel safety).
3. `sys_sigaction` now rejects non-canonical handler addresses to prevent SYSRETQ-induced kernel #GP from a malicious caller.
4. `replace_current_image` (sys_exec) now resets signal-handler bookkeeping so exec-from-handler doesn't leave stale frame pointers.

## Known limitations

- **RDI is not set to signum** at signal delivery. User handlers declared as `void handler(int signo)` will see undefined RDI. A VDSO trampoline upgrade (load signum from `[rsp+offsetof(SignalFrame.signal_number)]` into RDI before calling handler) is the proper fix; documented as TODO.
- **Caller-saved GPRs are zeroed** in the SignalFrame at delivery. Correct for syscall-boundary delivery (per System V ABI), but signal delivery from interrupt context (when added later) must populate them from the interrupt trap frame.
- **XSAVE / FP state** is not preserved across signal handlers (out of MVP scope, per spec §5.2).

## Branch base

Targets `phase-1-cross-platform-build` (PR #1). Merge order: Phase 1 first, then this.

## Test plan

- [ ] Local Linux: `just build` and `just build-image` succeed (kernel + bootloader build verified locally; userland workspace has pre-existing link issues unrelated to Phase 2).
- [ ] QEMU smoke: `just run-uefi` boots to racsh prompt — VDSO init line should appear in the serial log (`RACORE: VDSO initialised at phys 0x... mapped @ 0x7FFFFFFEF000`).
- [ ] Send SIGCHLD path: a forked child exits; parent's `waitpid` returns with SIGCHLD in pending mask.
- [ ] Sigreturn round-trip (deferred to Phase 2.1 integration test).
- [ ] Memory cleanup loop (deferred to Phase 2.1 integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)