### PR TITLE
T4.2 drivers + scheduler — three files to 0 missing (44 SAFETY)

### DIFF
--- a/kernel/src/drivers/ahci.rs
+++ b/kernel/src/drivers/ahci.rs
@@ -173,12 +173,14 @@ pub fn init(pci_devices: &[PciDevice]) -> Result<(), AhciError> {
     );
 
     // Bring HBA into AHCI mode.
+    // SAFETY: abar is the HBA's PCI BAR5, identity-mapped MMIO.
     unsafe {
         let ghc = mmio_r32(abar, HBA_GHC);
         mmio_w32(abar, HBA_GHC, ghc | GHC_AE);
     }
 
     // Pick the first implemented + present port.
+    // SAFETY: HBA MMIO read.
     let pi = unsafe { mmio_r32(abar, HBA_PI) };
     let mut chosen: Option<usize> = None;
     for i in 0..32 {
@@ -186,10 +188,12 @@ pub fn init(pci_devices: &[PciDevice]) -> Result<(), AhciError> {
             continue;
         }
         let port = port_regs(abar, i);
+        // SAFETY: port MMIO derived from abar + HBA_PORT_BASE + i*stride.
         let ssts = unsafe { mmio_r32(port, P_SSTS) };
         let det = ssts & 0x0F;
         let ipm = (ssts >> 8) & 0x0F;
         if det == 3 && ipm == 1 {
+            // SAFETY: same port MMIO.
             let sig = unsafe { mmio_r32(port, P_SIG) };
             if sig == SIG_ATA {
                 chosen = Some(i);
@@ -220,6 +224,7 @@ pub fn init(pci_devices: &[PciDevice]) -> Result<(), AhciError> {
 
 #[inline]
 fn port_regs(abar: *mut u8, idx: usize) -> *mut u8 {
+    // SAFETY: idx < 32 (validated by PI scan); offset stays within HBA MMIO.
     unsafe { abar.add(HBA_PORT_BASE + idx * HBA_PORT_STRIDE) }
 }
 
@@ -227,6 +232,7 @@ fn init_port(abar: *mut u8, idx: usize) -> Result<Port, AhciError> {
     let regs = port_regs(abar, idx);
 
     // Stop the port (CMD.ST=0, then wait CR=0; CMD.FRE=0, then wait FR=0).
+    // SAFETY: regs is this port's identity-mapped MMIO region.
     unsafe {
         let cmd = mmio_r32(regs, P_CMD);
         mmio_w32(regs, P_CMD, cmd & !PORT_CMD_ST);
@@ -251,6 +257,7 @@ fn init_port(abar: *mut u8, idx: usize) -> Result<Port, AhciError> {
     }
 
     // Link slot 0's command header to the command table.
+    // SAFETY: cmd_list_phys is a freshly-allocated identity-mapped frame.
     unsafe {
         let header = cmd_list_phys as *mut CmdHeader;
         write_volatile(&mut (*header).ctba, cmd_table_phys as u32);
@@ -258,6 +265,8 @@ fn init_port(abar: *mut u8, idx: usize) -> Result<Port, AhciError> {
     }
 
     // Program port base addresses and re-enable.
+    // SAFETY: regs is this port's MMIO; the frame phys addresses were just
+    // allocated and zeroed above.
     unsafe {
         mmio_w32(regs, P_CLB, cmd_list_phys as u32);
         mmio_w32(regs, P_CLBU, (cmd_list_phys >> 32) as u32);
@@ -272,6 +281,7 @@ fn init_port(abar: *mut u8, idx: usize) -> Result<Port, AhciError> {
 
     // Run IDENTIFY DEVICE to obtain sector count.
     let identify_phys = phys::alloc_frame().map_err(|_| AhciError::Io)?.addr();
+    // SAFETY: freshly-allocated identity-mapped frame, exclusively owned.
     unsafe {
         core::ptr::write_bytes(identify_phys as *mut u8, 0, 512);
     }
@@ -308,6 +318,8 @@ fn init_port(abar: *mut u8, idx: usize) -> Result<Port, AhciError> {
 
 fn read_identify_lba(buf_phys: u64) -> u64 {
     // ATA IDENTIFY: words 100..103 hold 48-bit LBA count (if word 83 bit 10 is set).
+    // SAFETY: buf_phys is the IDENTIFY landing frame (512 B). All offsets
+    // (60, 61, 83, 100..103) are within bounds.
     unsafe {
         let p = buf_phys as *const u16;
         let w83 = read_volatile(p.add(83));
@@ -381,6 +393,7 @@ fn submit_command(
     wait_ready(regs, 1_000_000)?;
 
     // Clear interrupt status, then issue slot 0.
+    // SAFETY: regs is this port's identity-mapped MMIO.
     unsafe {
         mmio_w32(regs, P_IS, 0xFFFF_FFFF);
         mmio_w32(regs, P_CI, 1);
@@ -388,20 +401,24 @@ fn submit_command(
 
     // Poll CI until cleared (= command complete) or TFD error.
     for _ in 0..50_000_000u64 {
+        // SAFETY: port MMIO read.
         let ci = unsafe { mmio_r32(regs, P_CI) };
         if ci & 1 == 0 {
             break;
         }
+        // SAFETY: port MMIO read.
         let tfd = unsafe { mmio_r32(regs, P_TFD) };
         if tfd & TFD_ERR != 0 {
             return Err(AhciError::Io);
         }
         core::hint::spin_loop();
     }
+    // SAFETY: port MMIO read.
     let ci = unsafe { mmio_r32(regs, P_CI) };
     if ci & 1 != 0 {
         return Err(AhciError::Io);
     }
+    // SAFETY: port MMIO read.
     let tfd = unsafe { mmio_r32(regs, P_TFD) };
     if tfd & TFD_ERR != 0 {
         return Err(AhciError::Io);
@@ -411,6 +428,7 @@ fn submit_command(
 
 fn wait_clear(regs: *mut u8, off: usize, mask: u32, spins: u64) -> Result<(), AhciError> {
     for _ in 0..spins {
+        // SAFETY: port MMIO read at a caller-supplied offset.
         let v = unsafe { mmio_r32(regs, off) };
         if v & mask == 0 {
             return Ok(());
@@ -422,6 +440,7 @@ fn wait_clear(regs: *mut u8, off: usize, mask: u32, spins: u64) -> Result<(), Ah
 
 fn wait_ready(regs: *mut u8, spins: u64) -> Result<(), AhciError> {
     for _ in 0..spins {
+        // SAFETY: port MMIO read.
         let tfd = unsafe { mmio_r32(regs, P_TFD) };
         if tfd & (TFD_BSY | TFD_DRQ) == 0 {
             return Ok(());
@@ -500,6 +519,8 @@ fn do_io(lba: u64, buf: &[u8], write: bool) -> BlockResult<()> {
             write,
         );
         if !write && res.is_ok() {
+            // SAFETY: scratch is owned + SECTOR_SIZE bytes; buf is the
+            // caller's sector-sized slice.
             unsafe {
                 core::ptr::copy_nonoverlapping(
                     scratch as *const u8,

--- a/kernel/src/drivers/virtio_net.rs
+++ b/kernel/src/drivers/virtio_net.rs
@@ -116,28 +116,34 @@ impl VirtioNet {
 
     fn bring_up(io_base: u16) -> Result<Self, VirtioNetError> {
         // 1. Reset.
+        // SAFETY: io_base belongs to this device's PCI BAR0 (I/O space).
         unsafe {
             outb(io_base + REG_DEVICE_STATUS, 0);
         }
 
         // 2/3. ACKNOWLEDGE | DRIVER.
         let mut status = STATUS_ACKNOWLEDGE;
+        // SAFETY: virtio device-status write, same PCI BAR.
         unsafe {
             outb(io_base + REG_DEVICE_STATUS, status);
         }
         status |= STATUS_DRIVER;
+        // SAFETY: virtio device-status write, same PCI BAR.
         unsafe {
             outb(io_base + REG_DEVICE_STATUS, status);
         }
 
         // 4. Feature negotiation — we only ask for VIRTIO_NET_F_MAC.
+        // SAFETY: device-features register read.
         let device_features = unsafe { inl(io_base + REG_DEVICE_FEATURES) };
         if device_features & VIRTIO_NET_F_MAC == 0 {
+            // SAFETY: device-status write to flag FAILED before bailing.
             unsafe {
                 outb(io_base + REG_DEVICE_STATUS, status | STATUS_FAILED);
             }
             return Err(VirtioNetError::FeatureNegotiation);
         }
+        // SAFETY: guest-features write completes the negotiation.
         unsafe {
             outl(io_base + REG_GUEST_FEATURES, VIRTIO_NET_F_MAC);
         }
@@ -145,6 +151,7 @@ impl VirtioNet {
         // 5. Read MAC from device-specific config.
         let mut mac = [0u8; 6];
         for i in 0..6 {
+            // SAFETY: device-config byte read, i < 6.
             unsafe {
                 mac[i] = inb(io_base + REG_DEVICE_CONFIG + i as u16);
             }
@@ -180,6 +187,7 @@ impl VirtioNet {
         dev.post_initial_rx()?;
 
         // 10. DRIVER_OK.
+        // SAFETY: final device-status write to flip DRIVER_OK.
         unsafe {
             outb(io_base + REG_DEVICE_STATUS, status | STATUS_DRIVER_OK);
         }
@@ -188,11 +196,13 @@ impl VirtioNet {
 
     fn setup_queue(io_base: u16, idx: u16) -> Result<Virtqueue, VirtioNetError> {
         // Select queue.
+        // SAFETY: queue-select write to virtio BAR.
         unsafe {
             outw(io_base + REG_QUEUE_SELECT, idx);
         }
         // Legacy I/O queue size is device-dictated and read-only. Our virtqueue
         // layout MUST match exactly or the device reads/writes outside it.
+        // SAFETY: queue-size register read.
         let dev_size = unsafe { inw(io_base + REG_QUEUE_SIZE) };
         crate::serial::serial_println!(
             "[ VIRTIO ] queue {} device-reported size={}",
@@ -210,6 +220,7 @@ impl VirtioNet {
         }
         let vq = Virtqueue::new().map_err(|_| VirtioNetError::QueueAlloc)?;
         // Tell device where the queue lives. Legacy I/O uses PFN.
+        // SAFETY: queue-address write tells the device our virtqueue PFN.
         unsafe {
             outl(io_base + REG_QUEUE_ADDRESS, vq.pfn());
         }
@@ -309,6 +320,7 @@ impl VirtioNet {
 
     /// Acknowledge the ISR (clear pending bit). Read is destructive.
     pub fn ack_isr(&self) -> u8 {
+        // SAFETY: ISR-status register read clears pending bit by side effect.
         unsafe { inb(self.io_base + REG_ISR_STATUS) }
     }
 }

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -229,12 +229,16 @@ impl Scheduler {
             })
             .unwrap_or(0);
         if incoming_kernel_stack_top != 0 {
+            // SAFETY: incoming task's kstack top was validated by the
+            // process::from_elf invariant; SYSCALL entry must see this RSP.
             unsafe {
                 crate::syscall::entry::set_kernel_rsp(incoming_kernel_stack_top);
                 crate::arch::gdt::set_kernel_stack(incoming_kernel_stack_top);
             }
         }
 
+        // SAFETY: context_switch saves/restores GP regs + RSP between two
+        // TaskContexts we own. Both ctx pointers were derived from &mut Task.
         unsafe {
             context::context_switch(old_ctx, new_ctx);
         }
@@ -261,6 +265,8 @@ impl Scheduler {
                 - (super::task::KERNEL_STACK_GUARD_PAGES * crate::mm::phys::FRAME_SIZE) as u64;
             // Check the first 8 bytes of the guard page. If any of those is
             // not the sentinel, overflow happened.
+            // SAFETY: guard_addr is the page immediately below this task's
+            // kernel stack — identity-mapped, allocated alongside the stack.
             let first_qword = unsafe { core::ptr::read_volatile(guard_addr as *const u64) };
             let expected_byte = super::task::KERNEL_STACK_GUARD_BYTE as u64;
             let expected_qword = expected_byte
@@ -317,6 +323,8 @@ impl Scheduler {
             }
 
             // Notify the parent about child state change.
+            // SAFETY: send_signal_to walks the task-table — we're already
+            // holding scheduler state mutably here.
             unsafe {
                 let _ = send_signal_to(parent_pid, super::signal::Signal::SIGCHLD);
             }
@@ -372,6 +380,9 @@ impl Scheduler {
 
                     // Free the user page table (and all mapped user frames)
                     if page_table_phys != 0 {
+                        // SAFETY: page_table_phys came from this zombie's
+                        // task struct; we just nulled the slot so no other
+                        // path references it.
                         unsafe {
                             crate::mm::virt::free_page_table(page_table_phys, true);
                         }
@@ -669,6 +680,8 @@ pub fn timer_tick() {
 
 /// Yield the current task.
 pub fn yield_now() {
+    // SAFETY: cli/sti window so the SCHEDULER static access is serialised
+    // against the timer-tick path.
     unsafe {
         core::arch::asm!("cli", options(nomem, nostack));
         if let Some(ref mut sched) = *core::ptr::addr_of_mut!(SCHEDULER) {
@@ -696,6 +709,7 @@ pub unsafe fn exit_current(status: i32) {
 
 /// Get the current PID.
 pub fn current_pid() -> Pid {
+    // SAFETY: read-only access to the SCHEDULER singleton.
     unsafe {
         (*core::ptr::addr_of!(SCHEDULER))
             .as_ref()
@@ -706,6 +720,7 @@ pub fn current_pid() -> Pid {
 
 /// Get the physical address of the current task's page table (0 = kernel task).
 pub fn current_page_table_phys() -> u64 {
+    // SAFETY: read-only access to the SCHEDULER singleton.
     unsafe {
         (*core::ptr::addr_of!(SCHEDULER))
             .as_ref()
@@ -716,6 +731,7 @@ pub fn current_page_table_phys() -> u64 {
 
 /// Get the kernel stack top of the current task.
 pub fn current_kernel_stack_top() -> u64 {
+    // SAFETY: read-only access to the SCHEDULER singleton.
     unsafe {
         (*core::ptr::addr_of!(SCHEDULER))
             .as_ref()
@@ -829,6 +845,7 @@ pub unsafe fn send_signal_to(pid: Pid, sig: super::signal::Signal) -> bool {
 /// Must be called with interrupts disabled.
 pub fn current_deliver_signal(sig_num: u8) {
     if let Some(sig) = super::signal::Signal::from_u8(sig_num) {
+        // SAFETY: caller (exception handler) runs with IF=0; SCHEDULER mut access.
         unsafe {
             if let Some(ref mut sched) = *core::ptr::addr_of_mut!(SCHEDULER) {
                 let idx = sched.current;
@@ -903,6 +920,7 @@ pub unsafe fn create_session() -> Pid {
 
 /// Get the current task's process group ID.
 pub fn current_pgid() -> Pid {
+    // SAFETY: read-only access to the SCHEDULER singleton.
     unsafe {
         (*core::ptr::addr_of!(SCHEDULER))
             .as_ref()
@@ -913,6 +931,7 @@ pub fn current_pgid() -> Pid {
 
 /// Get the current task's session ID.
 pub fn current_session_id() -> Pid {
+    // SAFETY: read-only access to the SCHEDULER singleton.
     unsafe {
         (*core::ptr::addr_of!(SCHEDULER))
             .as_ref()
@@ -993,6 +1012,7 @@ pub unsafe fn spawn_forked(task: super::task::Task) -> Result<Pid, &'static str>
 
 /// Get the parent PID of the current task.
 pub fn current_parent_pid() -> Pid {
+    // SAFETY: read-only access to the SCHEDULER singleton.
     unsafe {
         (*core::ptr::addr_of!(SCHEDULER))
             .as_ref()
@@ -1098,6 +1118,7 @@ pub unsafe fn set_cwd(path: &[u8]) -> bool {
 /// we send the signal to the currently running user process. If it's a
 /// kernel task (PID < 100), we skip.
 pub fn signal_foreground(sig: super::signal::Signal) {
+    // SAFETY: called from IRQ context (serial Ctrl-C); IF=0 implicit.
     unsafe {
         if let Some(ref mut sched) = *core::ptr::addr_of_mut!(SCHEDULER) {
             // Find the running user process (or any ready user process)


### PR DESCRIPTION
## Summary

Closes the §3.3 unsafe-block backlog for **three files in one PR**:

| File | Pre-PR | After |
|---|---|---|
| \`kernel/src/drivers/ahci.rs\` | 17 | **0** |
| \`kernel/src/task/scheduler.rs\` | 13 | **0** |
| \`kernel/src/drivers/virtio_net.rs\` | 12 | **0** |

**44 new \`// SAFETY:\` annotations** total.

### Patterns documented

**ahci.rs**:
- HBA MMIO reads/writes (GHC/PI/SSTS/SIG) and per-port MMIO (CMD/CLB/FB/SERR/IS/CI/TFD) — identity-mapped BAR5.
- Identity-mapped DMA frames for the command list, FIS, command table, IDENTIFY landing zone, and the do_io scratch buffer.
- \`read_identify_lba\` bounded by the 512 B IDENTIFY response.
- \`wait_clear\` / \`wait_ready\` MMIO spinners.

**scheduler.rs**:
- \`context_switch\` + \`set_kernel_rsp\`/\`set_kernel_stack\` for the incoming task's kstack top.
- \`check_kernel_stack_guards\` reading the per-task guard page sentinel.
- \`exit_current\`'s SIGCHLD send, \`free_page_table\` on a zombie's CR3.
- Public unsafe accessors that wrap the SCHEDULER singleton (\`current_*\`, \`with_*\`, \`signal_foreground\`, etc.) — pattern is "Must be called with interrupts disabled" per their doc-comments.

**virtio_net.rs**:
- Virtio legacy PCI-I/O register reads/writes (\`REG_DEVICE_STATUS\`, \`REG_DEVICE_FEATURES\`, \`REG_GUEST_FEATURES\`, \`REG_DEVICE_CONFIG\`, queue select/size/address, queue notify, ISR status).

## Lint progress

\`\`\`
$ bash scripts/check-unsafe-safety.sh | tail -1
scanned 456 unsafe blocks under kernel/ + libs/; 104 missing SAFETY
\`\`\`

- Before: 148 missing
- After this PR: 104 missing (−44)

## Build

\`\`\`
$ cargo build -p racore --target x86_64-unknown-none
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 1.79s
\`\`\`

Pure comments-only kernel change. No functional behaviour modified.

## T4.2 progress summary

Six files now fully covered (0 missing each):
- ✅ \`kernel/src/syscall/handlers.rs\` (was 95)
- ✅ \`libs/libc-lite/src/lib.rs\` (was 78)
- ✅ \`kernel/src/main.rs\` (was 36)
- ✅ \`kernel/src/drivers/ahci.rs\` (was 17)
- ✅ \`kernel/src/task/scheduler.rs\` (was 13)
- ✅ \`kernel/src/drivers/virtio_net.rs\` (was 12)

**Total: 350 → 104 missing across 9 merged PRs.**

## Follow-ups

Remaining smaller files (104 missing total):
- \`elf.rs\` (8), \`vfs/fat32.rs\` (7), \`tty/vt.rs\` (7), \`arch/idt.rs\` (7)
- Plus various smaller files across arch/, drivers/, net/, vfs/, mm/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)