### PR TITLE
T4.2 sweep — elf + fat32 + vt + idt to 0 missing (29 SAFETY)

### DIFF
--- a/kernel/src/arch/idt.rs
+++ b/kernel/src/arch/idt.rs
@@ -70,6 +70,8 @@ macro_rules! exception_handler {
             // some toolchains. Fall back to reading the canonical CPU-pushed
             // frame from TSS.RSP0 - 40 so the printout is always correct.
             let rsp0 = crate::arch::gdt::current_kernel_stack();
+            // SAFETY: TSS.RSP0-40 is the canonical IRET frame the CPU
+            // pushed on entry to this exception handler.
             let frame_words: [u64; 5] = unsafe {
                 core::ptr::read_unaligned(rsp0.wrapping_sub(40) as *const [u64; 5])
             };
@@ -81,6 +83,7 @@ macro_rules! exception_handler {
                 crate::task::scheduler::current_pid(),
             );
             loop {
+                // SAFETY: cli; hlt to park the CPU after an unrecoverable exception.
                 unsafe { core::arch::asm!("cli; hlt", options(nomem, nostack)); }
             }
         }
@@ -97,6 +100,7 @@ macro_rules! exception_handler_with_error {
                 error_code
             );
             loop {
+                // SAFETY: cli; hlt — unrecoverable exception, park CPU.
                 unsafe {
                     core::arch::asm!("cli; hlt", options(nomem, nostack));
                 }
@@ -139,6 +143,7 @@ extern "x86-interrupt" fn page_fault(stack_frame: &InterruptStackFrame, error_co
     let current_is_user_task =
         current_pid >= 100 && crate::task::scheduler::current_page_table_phys() != 0;
     let fault_addr: u64;
+    // SAFETY: reading CR2 — always valid in ring 0; holds the faulting linear address.
     unsafe {
         core::arch::asm!("mov {}, cr2", out(reg) fault_addr, options(nomem, nostack));
     }
@@ -155,6 +160,7 @@ extern "x86-interrupt" fn page_fault(stack_frame: &InterruptStackFrame, error_co
         );
         // Signal handling is not complete yet; terminate immediately to avoid
         // fault loops on the same instruction.
+        // SAFETY: exit_current — caller is the page-fault handler with IF=0.
         unsafe {
             crate::task::scheduler::exit_current(128 + 11);
         }
@@ -169,6 +175,7 @@ extern "x86-interrupt" fn page_fault(stack_frame: &InterruptStackFrame, error_co
         error_code,
     );
     loop {
+        // SAFETY: cli; hlt — unrecoverable kernel page fault, park CPU.
         unsafe {
             core::arch::asm!("cli; hlt", options(nomem, nostack));
         }
@@ -236,6 +243,8 @@ extern "x86-interrupt" fn lapic_timer_handler(_stack_frame: &InterruptStackFrame
     // Bump this CPU's own counter via GS base. No `lock` prefix: only the
     // owning CPU writes its tick_count, so an atomic RMW is overkill and
     // we want a single non-locked memory op in the IRQ fast path.
+    // SAFETY: GS base was set by arch::percpu::init_for_this_cpu to point
+    // at this CPU's PerCpu slot; OFFSET_TICK_COUNT is within that slot.
     unsafe {
         core::arch::asm!(
             "inc qword ptr gs:[{off}]",

--- a/kernel/src/elf.rs
+++ b/kernel/src/elf.rs
@@ -210,7 +210,9 @@ fn apply_relocations(
     let mut rela_ent_size: usize = core::mem::size_of::<Elf64Rela>();
 
     for i in 0..dyn_count {
+        // SAFETY: i < dyn_count = dynamic_size / dyn_ent_size; offset stays in range.
         let ent_ptr = unsafe { dyn_ptr.add(i * dyn_ent_size) as *const Elf64Dyn };
+        // SAFETY: ent_ptr is bounded; read_unaligned handles packed Elf64Dyn.
         let ent: Elf64Dyn = unsafe { core::ptr::read_unaligned(ent_ptr) };
         let tag = ent.d_tag;
         let val = ent.d_val;
@@ -245,7 +247,9 @@ fn apply_relocations(
     let mut applied = 0usize;
 
     for i in 0..rela_count {
+        // SAFETY: i < rela_count = rela_size / rela_ent_size; offset stays in range.
         let ent_ptr = unsafe { rela_ptr.add(i * rela_ent_size) as *const Elf64Rela };
+        // SAFETY: ent_ptr is bounded; read_unaligned handles packed Elf64Rela.
         let rela: Elf64Rela = unsafe { core::ptr::read_unaligned(ent_ptr) };
 
         let r_offset = rela.r_offset;
@@ -257,6 +261,8 @@ fn apply_relocations(
             let place_vaddr = runtime_vaddr(r_offset, load_bias)?;
             let place_ptr = resolve_loaded_ptr(segments, seg_count, place_vaddr, 8)?;
             let relocated = load_bias.wrapping_add(r_addend as u64);
+            // SAFETY: resolve_loaded_ptr confirmed 8 bytes fit at place_ptr
+            // within a loaded segment.
             unsafe {
                 core::ptr::write_unaligned(place_ptr as *mut u64, relocated);
             }
@@ -403,6 +409,7 @@ pub fn load_elf(data: &[u8]) -> Result<LoadedElf, ElfError> {
         let phys_addr = frame.addr();
 
         // Zero the entire allocation (for BSS)
+        // SAFETY: freshly-allocated identity-mapped frames, exclusively owned.
         unsafe {
             core::ptr::write_bytes(phys_addr as *mut u8, 0, pages * FRAME_SIZE);
         }
@@ -410,6 +417,8 @@ pub fn load_elf(data: &[u8]) -> Result<LoadedElf, ElfError> {
         // Copy file data into the physical allocation
         if p_filesz > 0 {
             let src = &data[p_offset as usize..file_end];
+            // SAFETY: src bounded by file_end <= data.len(); dst within our
+            // freshly-allocated pages*FRAME_SIZE region.
             unsafe {
                 core::ptr::copy_nonoverlapping(
                     src.as_ptr(),
@@ -450,6 +459,7 @@ pub fn load_elf(data: &[u8]) -> Result<LoadedElf, ElfError> {
     let stack_phys = stack_frame.addr();
 
     // Zero the stack
+    // SAFETY: freshly-allocated user stack pages, exclusively owned.
     unsafe {
         core::ptr::write_bytes(stack_phys as *mut u8, 0, USER_STACK_SIZE);
     }

--- a/kernel/src/tty/vt.rs
+++ b/kernel/src/tty/vt.rs
@@ -162,6 +162,7 @@ impl VirtualTerminal {
 
         // If this VT is active, we also write to the actual framebuffer
         if self.active {
+            // SAFETY: fb_console singleton initialised once at boot.
             if let Some(console) = unsafe { get_console() } {
                 console.put_char(c);
             }
@@ -192,6 +193,7 @@ impl VirtualTerminal {
         self.cursor_y = 0;
 
         if self.active {
+            // SAFETY: fb_console singleton initialised once at boot.
             if let Some(console) = unsafe { get_console() } {
                 console.clear();
             }
@@ -207,6 +209,7 @@ impl VirtualTerminal {
 
     /// Redraw this VT from its buffer.
     pub fn redraw(&self) {
+        // SAFETY: fb_console singleton initialised once at boot.
         if let Some(console) = unsafe { get_console() } {
             console.clear();
 
@@ -240,6 +243,7 @@ impl VtManager {
     pub fn new() -> Self {
         let mut vts = Vec::new();
         // Get actual dimensions from the framebuffer console, fall back to 80x25.
+        // SAFETY: fb_console singleton initialised once at boot.
         let (cols, rows) = unsafe {
             if let Some(console) = get_console() {
                 (console.cols(), console.rows())
@@ -279,6 +283,7 @@ impl VtManager {
 static mut VT_MANAGER: Option<VtManager> = None;
 
 pub fn init() {
+    // SAFETY: VT_MANAGER is set once at boot.
     unsafe {
         VT_MANAGER = Some(VtManager::new());
     }
@@ -297,6 +302,7 @@ pub unsafe fn get_manager() -> &'static mut VtManager {
 /// multiple sys_write calls — producing garbage like `[K[14C` after every
 /// backspace in racsh.
 pub fn vt_print(s: &str) {
+    // SAFETY: VT_MANAGER + fb_console are boot-once singletons; single-CPU MVP.
     unsafe {
         if let Some(mgr) = VT_MANAGER.as_mut() {
             // Update the off-screen VT buffer with stripped text (skip CSI).
@@ -310,6 +316,7 @@ pub fn vt_print(s: &str) {
 }
 
 pub fn vt_clear_current() {
+    // SAFETY: VT_MANAGER is a boot-once singleton; single-CPU MVP.
     unsafe {
         if let Some(mgr) = VT_MANAGER.as_mut() {
             mgr.current().clear();

--- a/kernel/src/vfs/fat32.rs
+++ b/kernel/src/vfs/fat32.rs
@@ -227,6 +227,8 @@ impl Fat32Fs {
             .read_sector(0, &mut sector)
             .map_err(|_| VfsError::IoError)?;
 
+        // SAFETY: sector is SECTOR_SIZE bytes which exceeds sizeof(BpbFat32);
+        // read_unaligned handles the packed struct layout.
         let bpb: BpbFat32 =
             unsafe { core::ptr::read_unaligned(sector.as_ptr() as *const BpbFat32) };
 
@@ -327,6 +329,8 @@ impl Fat32Fs {
         self.device
             .read_sector(fat_sector, &mut sector_data)
             .map_err(|_| VfsError::IoError)?;
+        // SAFETY: offset = (cluster*4) % SECTOR_SIZE so [offset, offset+4) is
+        // within sector_data; read_unaligned handles the unaligned u32 read.
         let entry =
             unsafe { core::ptr::read_unaligned(sector_data.as_ptr().add(offset) as *const u32) };
         Ok(entry & FAT_ENTRY_MASK)
@@ -346,8 +350,10 @@ impl Fat32Fs {
             self.device
                 .read_sector(lba, &mut buf)
                 .map_err(|_| VfsError::IoError)?;
+            // SAFETY: offset fits within a SECTOR_SIZE buffer (same calc as above).
             let old = unsafe { core::ptr::read_unaligned(buf.as_ptr().add(offset) as *const u32) };
             let new = (old & 0xF000_0000) | value;
+            // SAFETY: same bounded offset.
             unsafe {
                 core::ptr::write_unaligned(buf.as_mut_ptr().add(offset) as *mut u32, new);
             }
@@ -569,6 +575,9 @@ impl Fat32Fs {
                     .map_err(|_| VfsError::IoError)?;
                 for slot in 0..(SECTOR_SIZE / DIR_ENTRY_SIZE) {
                     let off = slot * DIR_ENTRY_SIZE;
+                    // SAFETY: off = slot * DIR_ENTRY_SIZE < SECTOR_SIZE and
+                    // DIR_ENTRY_SIZE >= sizeof(FatDirEntry); read_unaligned
+                    // handles the packed dir-entry layout.
                     let entry: FatDirEntry = unsafe {
                         core::ptr::read_unaligned(sector.as_ptr().add(off) as *const FatDirEntry)
                     };
@@ -631,6 +640,7 @@ impl Fat32Fs {
             .read_sector(lba, &mut sector)
             .map_err(|_| VfsError::IoError)?;
         let off = slot * DIR_ENTRY_SIZE;
+        // SAFETY: off < SECTOR_SIZE; DIR_ENTRY_SIZE >= sizeof(FatDirEntry).
         unsafe {
             core::ptr::write_unaligned(sector.as_mut_ptr().add(off) as *mut FatDirEntry, *entry);
         }
@@ -1139,6 +1149,7 @@ pub fn format_fat32(device: Arc<dyn BlockDevice>, label: &str) -> VfsResult<Arc<
 
     // Sector 0: boot sector with BPB + signature.
     let mut boot = [0u8; SECTOR_SIZE];
+    // SAFETY: BpbFat32 (~90 bytes) fits in SECTOR_SIZE (512 bytes).
     unsafe {
         core::ptr::write_unaligned(boot.as_mut_ptr() as *mut BpbFat32, bpb);
     }


### PR DESCRIPTION
## Summary

Sweep through four smaller files, closing each one to **0 missing**:

| File | Pre-PR | After |
|---|---|---|
| \`kernel/src/arch/idt.rs\` | 7 | **0** |
| \`kernel/src/elf.rs\` | 8 | **0** |
| \`kernel/src/tty/vt.rs\` | 7 | **0** |
| \`kernel/src/vfs/fat32.rs\` | 7 | **0** |

**29 new \`// SAFETY:\` annotations** total.

### Patterns documented

**idt.rs**:
- IRET-frame read from \`TSS.RSP0-40\` in the exception-handler macro.
- \`cli; hlt\` loops parking the CPU on unrecoverable exceptions.
- CR2 read in the page-fault handler; \`exit_current\` on user-fault.
- LAPIC-timer \`gs:[OFFSET_TICK_COUNT]\` inc.

**elf.rs**:
- \`read_unaligned\` bounded by per-loop \`i < count\` for both Elf64Dyn and Elf64Rela tables.
- \`write_unaligned\` at \`resolve_loaded_ptr\`-validated places (RELATIVE rela).
- \`write_bytes\` / \`copy_nonoverlapping\` into freshly-allocated, owned segment and user-stack frames.

**vt.rs**:
- \`get_console()\` singleton (six call sites: put_char, clear, redraw, size query, vt_print).
- \`VT_MANAGER\` static (init, vt_print, vt_clear_current) — single-CPU MVP.

**fat32.rs**:
- \`read_unaligned\` of \`BpbFat32\` from the boot sector buffer.
- \`read_unaligned\` / \`write_unaligned\` of FAT entries at the bounded offset \`(cluster * 4) % SECTOR_SIZE\`.
- \`read_unaligned\` / \`write_unaligned\` of \`FatDirEntry\` at \`slot * DIR_ENTRY_SIZE\`.
- \`write_unaligned\` of \`BpbFat32\` into the boot sector buffer in mkfs.

## Lint progress

\`\`\`
$ bash scripts/check-unsafe-safety.sh | tail -1
scanned 456 unsafe blocks under kernel/ + libs/; 75 missing SAFETY
\`\`\`

- Before: 104 missing
- After this PR: 75 missing (−29)

## Build

\`\`\`
$ cargo build -p racore --target x86_64-unknown-none
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 1.67s
\`\`\`

Pure comments-only kernel change. No functional behaviour modified.

## T4.2 progress summary

**Ten files now fully covered** (0 missing each):
- ✅ \`kernel/src/syscall/handlers.rs\` (was 95)
- ✅ \`libs/libc-lite/src/lib.rs\` (was 78)
- ✅ \`kernel/src/main.rs\` (was 36)
- ✅ \`kernel/src/drivers/ahci.rs\` (was 17)
- ✅ \`kernel/src/task/scheduler.rs\` (was 13)
- ✅ \`kernel/src/drivers/virtio_net.rs\` (was 12)
- ✅ \`kernel/src/elf.rs\` (was 8)
- ✅ \`kernel/src/arch/idt.rs\` (was 7)
- ✅ \`kernel/src/tty/vt.rs\` (was 7)
- ✅ \`kernel/src/vfs/fat32.rs\` (was 7)

**Total session progress: 350 → 75 missing across 10 merged PRs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)