### PR TITLE
T4.2 sweep — kernel + libs to 0 missing — backlog COMPLETE (75 SAFETY)

### DIFF
--- a/kernel/src/arch/acpi.rs
+++ b/kernel/src/arch/acpi.rs
@@ -210,6 +210,7 @@ pub unsafe fn init(rsdp_addr: u64) {
 }
 
 pub fn get_info() -> Option<&'static AcpiInfo> {
+    // SAFETY: ACPI_INFO is set once by arch::acpi::init at boot.
     unsafe { ACPI_INFO.as_ref() }
 }
 

--- a/kernel/src/arch/gdt.rs
+++ b/kernel/src/arch/gdt.rs
@@ -140,6 +140,7 @@ pub unsafe fn set_kernel_stack(rsp0: u64) {
 
 /// Read the current TSS.RSP0 (kernel stack pointer for ring 3 → ring 0).
 pub fn current_kernel_stack() -> u64 {
+    // SAFETY: TSS is a static singleton, this is a single field read.
     unsafe { (*core::ptr::addr_of!(TSS)).rsp0 }
 }
 
@@ -209,11 +210,13 @@ unsafe fn install_tss() {
         // bytes 4-7 are reserved (0)
         buf
     };
+    // SAFETY: GdtEntry is 8 bytes repr(C) of plain integer fields; high_bytes is [u8; 8].
     gdt[6] = unsafe { core::mem::transmute(high_bytes) };
 }
 
 /// Load the GDT, set segment registers, install and load TSS.
 pub fn init() {
+    // SAFETY: boot-once GDT install + segment reload + LTR; called before IRQs.
     unsafe {
         // Install TSS descriptor into GDT slots 5-6
         install_tss();

--- a/kernel/src/arch/lapic.rs
+++ b/kernel/src/arch/lapic.rs
@@ -140,6 +140,7 @@ pub fn is_enabled() -> bool {
     if base == 0 {
         return false;
     }
+    // SAFETY: LAPIC_BASE is non-zero, set once by init_bsp.
     unsafe { read_reg(LAPIC_REG_SVR) & SVR_ENABLE != 0 }
 }
 
@@ -151,6 +152,7 @@ pub fn current_apic_id() -> u32 {
     if base == 0 {
         return 0;
     }
+    // SAFETY: LAPIC_BASE non-zero; ID register read.
     unsafe { (read_reg(LAPIC_REG_ID) >> 24) & 0xFF }
 }
 
@@ -203,6 +205,7 @@ pub fn eoi() {
     if base == 0 {
         return;
     }
+    // SAFETY: LAPIC_BASE non-zero; EOI write is idempotent.
     unsafe {
         write_reg(LAPIC_REG_EOI, 0);
     }
@@ -215,6 +218,7 @@ pub fn eoi() {
 /// after ~1M spins so a wedged controller can't hang the kernel.
 fn wait_delivery() -> Result<(), &'static str> {
     for _ in 0..1_000_000u32 {
+        // SAFETY: LAPIC_BASE is set by init_bsp before any IPI helper is called.
         let v = unsafe { read_reg(LAPIC_REG_ICR_LOW) };
         if v & ICR_STATUS_PENDING == 0 {
             return Ok(());

--- a/kernel/src/arch/mod.rs
+++ b/kernel/src/arch/mod.rs
@@ -72,6 +72,7 @@ fn detect_features() -> CpuFeatures {
     // CPUID.0:EAX gives the maximum standard leaf. Bail out early if leaf 7
     // isn't supported (very old CPUs / minimal hypervisor models).
     let max_leaf: u32;
+    // SAFETY: CPUID leaf 0 — always available on x86_64.
     unsafe {
         core::arch::asm!(
             "push rbx",
@@ -92,6 +93,7 @@ fn detect_features() -> CpuFeatures {
     }
     // CPUID leaf 7, sub-leaf 0 → feature bits in EBX.
     let ebx: u32;
+    // SAFETY: CPUID leaf 7 — max_leaf check above confirms it's supported.
     unsafe {
         core::arch::asm!(
             "push rbx",
@@ -140,6 +142,7 @@ fn enable_smep_smap() {
     if f.smap {
         bits |= 1 << 21;
     }
+    // SAFETY: CR4 read+write; only setting SMEP/SMAP bits gated by CPUID detection.
     unsafe {
         let mut cr4: u64;
         core::arch::asm!("mov {}, cr4", out(reg) cr4, options(nomem, nostack));
@@ -156,6 +159,7 @@ fn enable_smep_smap() {
 /// Halt the CPU until the next interrupt.
 #[inline(always)]
 pub fn halt() {
+    // SAFETY: hlt pauses the CPU until next IRQ; always valid in ring 0.
     unsafe {
         core::arch::asm!("hlt", options(nomem, nostack));
     }

--- a/kernel/src/arch/percpu.rs
+++ b/kernel/src/arch/percpu.rs
@@ -119,6 +119,7 @@ pub unsafe fn init_for_this_cpu(apic_id: u32) {
 #[inline]
 pub fn current() -> &'static PerCpu {
     let ptr: *const PerCpu;
+    // SAFETY: reads GS base — init_for_this_cpu sets it to this CPU's PerCpu slot.
     unsafe {
         core::arch::asm!(
             "mov {}, gs:[0]",

--- a/kernel/src/arch/smp.rs
+++ b/kernel/src/arch/smp.rs
@@ -145,6 +145,7 @@ pub fn started_count() -> usize {
     let n = cpu_count();
     let mut c = 0usize;
     for i in 0..n {
+        // SAFETY: i < cpu_count <= MAX_CPUS; CPUS slot's `started` is its own atomic.
         unsafe {
             if CPUS[i].started.load(Ordering::SeqCst) {
                 c += 1;
@@ -164,6 +165,7 @@ pub fn bsp_apic_id() -> u32 {
 pub fn mark_started(apic_id: u32) {
     let n = cpu_count();
     for i in 0..n {
+        // SAFETY: i < cpu_count <= MAX_CPUS; slot apic_id+started both atomic.
         unsafe {
             if CPUS[i].apic_id == apic_id {
                 CPUS[i].started.store(true, Ordering::SeqCst);
@@ -177,6 +179,7 @@ pub fn mark_started(apic_id: u32) {
 pub fn for_each_cpu<R, F: FnMut(&CpuState) -> Option<R>>(mut f: F) -> Option<R> {
     let n = cpu_count();
     for i in 0..n {
+        // SAFETY: i < cpu_count <= MAX_CPUS.
         unsafe {
             if let Some(r) = f(&CPUS[i]) {
                 return Some(r);

--- a/kernel/src/drivers/block.rs
+++ b/kernel/src/drivers/block.rs
@@ -115,6 +115,7 @@ pub unsafe fn register(device: Arc<dyn BlockDevice>) {
 }
 
 pub fn count() -> usize {
+    // SAFETY: read-only access to the DEVICES singleton (initialised at boot).
     unsafe {
         (*core::ptr::addr_of!(DEVICES))
             .as_ref()
@@ -125,6 +126,7 @@ pub fn count() -> usize {
 
 /// Get a block device by index.
 pub fn get(index: usize) -> Option<Arc<dyn BlockDevice>> {
+    // SAFETY: read-only access to the DEVICES singleton.
     unsafe {
         (*core::ptr::addr_of!(DEVICES))
             .as_ref()?
@@ -135,6 +137,7 @@ pub fn get(index: usize) -> Option<Arc<dyn BlockDevice>> {
 
 /// Find a block device by name.
 pub fn find(name: &str) -> Option<Arc<dyn BlockDevice>> {
+    // SAFETY: read-only access to the DEVICES singleton.
     let devs = unsafe { (*core::ptr::addr_of!(DEVICES)).as_ref()? };
     devs.iter().find(|d| d.name() == name).cloned()
 }

--- a/kernel/src/drivers/mod.rs
+++ b/kernel/src/drivers/mod.rs
@@ -19,6 +19,7 @@ pub mod virtqueue;
 pub static NIC: SpinLock<Option<Box<virtio_net::VirtioNet>>> = SpinLock::new(None);
 
 pub fn init() {
+    // SAFETY: boot-once drivers init sequence; IRQs still off.
     unsafe {
         block::init();
         block::init_default_ramdisk();

--- a/kernel/src/drivers/pci.rs
+++ b/kernel/src/drivers/pci.rs
@@ -44,6 +44,7 @@ impl PciDevice {
             | ((self.func as u32) << 8)
             | ((offset as u32) & 0xFC)
             | 0x80000000;
+        // SAFETY: PCI configuration space CF8/CFC ports — architectural.
         unsafe {
             outl(PCI_CONFIG_ADDRESS, address);
             inl(PCI_CONFIG_DATA)
@@ -56,6 +57,7 @@ impl PciDevice {
             | ((self.func as u32) << 8)
             | ((offset as u32) & 0xFC)
             | 0x80000000;
+        // SAFETY: PCI configuration space CF8/CFC ports — architectural.
         unsafe {
             outl(PCI_CONFIG_ADDRESS, address);
             outl(PCI_CONFIG_DATA, value);
@@ -165,6 +167,7 @@ fn pci_read_u16(bus: u8, slot: u8, func: u8, offset: u8) -> u16 {
         | ((func as u32) << 8)
         | ((offset as u32) & 0xFC)
         | 0x80000000;
+    // SAFETY: PCI configuration space CF8/CFC ports — architectural.
     unsafe {
         outl(PCI_CONFIG_ADDRESS, address);
         let val = inl(PCI_CONFIG_DATA);
@@ -178,6 +181,7 @@ fn pci_read_u32(bus: u8, slot: u8, func: u8, offset: u8) -> u32 {
         | ((func as u32) << 8)
         | ((offset as u32) & 0xFC)
         | 0x80000000;
+    // SAFETY: PCI configuration space CF8/CFC ports — architectural.
     unsafe {
         outl(PCI_CONFIG_ADDRESS, address);
         inl(PCI_CONFIG_DATA)

--- a/kernel/src/drivers/ps2_keyboard.rs
+++ b/kernel/src/drivers/ps2_keyboard.rs
@@ -145,6 +145,7 @@ pub fn handle_irq_input() {
     }
 
     IRQ_COUNT.fetch_add(1, Ordering::AcqRel);
+    // SAFETY: PS/2 I/O port read; called from IRQ context with IF=0.
     unsafe {
         if is_data_available() {
             let scancode = read_scancode();

--- a/kernel/src/fb_console.rs
+++ b/kernel/src/fb_console.rs
@@ -771,6 +771,8 @@ impl FramebufferConsole {
         let stride = self.pitch / 4; // pixels per scanline (accounts for padding)
 
         // Move all lines up by one character row
+        // SAFETY: fb_addr is the bootloader-supplied framebuffer base; the
+        // src/dst ranges are within (rows-1) * char_height * stride pixels.
         unsafe {
             ptr::copy(
                 self.fb_addr.add((self.char_height * stride) as usize),
@@ -782,6 +784,7 @@ impl FramebufferConsole {
         // Clear the bottom line
         let bottom_start = ((self.rows - 1) * self.char_height * stride) as usize;
         for i in 0..(self.char_height * stride) as usize {
+            // SAFETY: bottom_start + i stays within the framebuffer pixel grid.
             unsafe {
                 *self.fb_addr.add(bottom_start + i) = bg_color;
             }
@@ -818,6 +821,8 @@ impl FramebufferConsole {
         }
 
         let offset = (y * (self.pitch / 4) + x) as usize;
+        // SAFETY: bounds check above (x < width, y < height) keeps offset
+        // within the framebuffer pixel grid.
         unsafe {
             *self.fb_addr.add(offset) = color;
         }
@@ -864,6 +869,7 @@ pub unsafe fn init(boot_info: &BootInfo) {
 
 /// Write to framebuffer console (if available).
 pub fn fb_print(s: &str) {
+    // SAFETY: FB_CONSOLE is boot-initialised; single-CPU MVP.
     unsafe {
         if let Some(console) = get_console() {
             console.write_str(s);
@@ -873,6 +879,7 @@ pub fn fb_print(s: &str) {
 
 /// Check if framebuffer console is available.
 pub fn is_available() -> bool {
+    // SAFETY: read-only check of the FB_CONSOLE Option discriminant.
     unsafe { FB_CONSOLE.is_some() }
 }
 

--- a/kernel/src/interrupts/pic.rs
+++ b/kernel/src/interrupts/pic.rs
@@ -88,6 +88,7 @@ pub fn enable_irq(irq: u8) {
 pub fn disable_irq(irq: u8) {
     let port = if irq < 8 { PIC1_DATA } else { PIC2_DATA };
     let line = if irq < 8 { irq } else { irq - 8 };
+    // SAFETY: PIC data port I/O — architectural fixed ports 0x21/0xA1.
     unsafe {
         let mask = inb(port);
         outb(port, mask | (1 << line));
@@ -107,6 +108,7 @@ pub fn send_eoi(irq: u8) {
 
 /// Mask all IRQs (disable all).
 pub fn disable_all() {
+    // SAFETY: PIC data port I/O — masks all IRQs at the PICs.
     unsafe {
         outb(PIC1_DATA, 0xFF);
         outb(PIC2_DATA, 0xFF);

--- a/kernel/src/interrupts/pit.rs
+++ b/kernel/src/interrupts/pit.rs
@@ -34,6 +34,7 @@ static TICK_COUNT: AtomicU64 = AtomicU64::new(0);
 /// real time. Same code path is a no-op on hardware without HPET (vendor
 /// reads as 0 or 0xFFFF and we bail).
 pub fn init() {
+    // SAFETY: boot-once PIT init; PIT command/data ports are architectural.
     unsafe {
         disable_hpet_legacy();
     }

--- a/kernel/src/mm/heap.rs
+++ b/kernel/src/mm/heap.rs
@@ -95,6 +95,7 @@ impl KernelHeapAllocator {
                 if prev.is_null() {
                     self.head = block.next;
                 } else {
+                    // SAFETY: prev is a valid free-block pointer from the walk above.
                     unsafe {
                         (*prev).next = block.next;
                     }
@@ -103,6 +104,7 @@ impl KernelHeapAllocator {
 
                 // If there's enough space after the allocation, create a new free block
                 if remaining >= MIN_BLOCK_SIZE {
+                    // SAFETY: alloc_end < block_end (checked), enough room for FreeBlock header.
                     unsafe {
                         let new_block = alloc_end as *mut FreeBlock;
                         (*new_block).size = remaining;
@@ -113,6 +115,7 @@ impl KernelHeapAllocator {
 
                 // If there's enough space before the allocation (alignment padding), keep it
                 if front_padding >= MIN_BLOCK_SIZE {
+                    // SAFETY: block_start is the original free-block address; we're reusing it.
                     unsafe {
                         let front_block = block_start as *mut FreeBlock;
                         (*front_block).size = front_padding;
@@ -202,6 +205,7 @@ impl KernelHeapAllocator {
         match phys::alloc_contiguous(frames_needed) {
             Ok(frame) => {
                 let base = frame.addr() as usize;
+                // SAFETY: freshly-allocated frames; identity-mapped; exclusively owned.
                 unsafe {
                     let block = base as *mut FreeBlock;
                     (*block).size = frames_needed * FRAME_SIZE;

--- a/kernel/src/mm/phys.rs
+++ b/kernel/src/mm/phys.rs
@@ -341,20 +341,24 @@ pub fn alloc_frame() -> Result<PhysFrame, FrameError> {
 
 /// Allocate `count` contiguous physical frames.
 pub fn alloc_contiguous(count: usize) -> Result<PhysFrame, FrameError> {
+    // SAFETY: FRAME_ALLOCATOR is boot-initialised; methods use atomic counters.
     unsafe { (*core::ptr::addr_of!(FRAME_ALLOCATOR)).alloc_contiguous(count) }
 }
 
 /// Free a physical frame.
 pub fn free_frame(frame: PhysFrame) -> Result<(), FrameError> {
+    // SAFETY: FRAME_ALLOCATOR is boot-initialised.
     unsafe { (*core::ptr::addr_of!(FRAME_ALLOCATOR)).free(frame) }
 }
 
 /// Number of free frames.
 pub fn free_count() -> usize {
+    // SAFETY: FRAME_ALLOCATOR is boot-initialised; read-only.
     unsafe { (*core::ptr::addr_of!(FRAME_ALLOCATOR)).free_frame_count() }
 }
 
 /// Total number of usable frames.
 pub fn total_count() -> usize {
+    // SAFETY: FRAME_ALLOCATOR is boot-initialised; read-only.
     unsafe { (*core::ptr::addr_of!(FRAME_ALLOCATOR)).usable_frame_count() }
 }

--- a/kernel/src/mm/virt.rs
+++ b/kernel/src/mm/virt.rs
@@ -435,6 +435,7 @@ pub unsafe fn capture_kernel_cr3() {
 /// Returns the physical address of the new PML4.
 pub fn create_user_page_table() -> Result<u64, &'static str> {
     let new_pml4_phys = alloc_page_table()?;
+    // SAFETY: KERNEL_PML4_PHYS captured once at boot; fallback to CR3 read if zero.
     let kernel_pml4_phys = unsafe {
         let cached = KERNEL_PML4_PHYS;
         if cached != 0 {

--- a/kernel/src/mod_loader.rs
+++ b/kernel/src/mod_loader.rs
@@ -32,6 +32,7 @@ impl ModuleManager {
 static mut MODULE_MANAGER: Option<ModuleManager> = None;
 
 pub fn init() {
+    // SAFETY: boot-once MODULE_MANAGER initialisation.
     unsafe {
         MODULE_MANAGER = Some(ModuleManager::new());
     }

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -159,6 +159,7 @@ impl NetState {
 static mut NET_STATE: Option<NetState> = None;
 
 fn state_mut() -> &'static mut NetState {
+    // SAFETY: NET_STATE singleton initialised lazily; single-CPU MVP.
     unsafe {
         if (*core::ptr::addr_of!(NET_STATE)).is_none() {
             *core::ptr::addr_of_mut!(NET_STATE) = Some(NetState::new());

--- a/kernel/src/net/stack.rs
+++ b/kernel/src/net/stack.rs
@@ -188,6 +188,7 @@ pub fn resolve(name: &str) -> Option<[u8; 4]> {
     // Wait up to 3 seconds for the reply (or 1 retransmission).
     // The SYSCALL path enters with IF=0 (SFMASK clears it). Enable interrupts
     // for the duration of the wait so the PIT can fire and poll the NIC.
+    // SAFETY: bare sti — explicitly enable IRQs for the resolve spin-wait.
     unsafe {
         core::arch::asm!("sti", options(nomem, nostack));
     }
@@ -222,6 +223,7 @@ pub fn resolve(name: &str) -> Option<[u8; 4]> {
         poll();
         core::hint::spin_loop();
     };
+    // SAFETY: bare cli — restore SYSCALL-entry IF=0 invariant before SYSRETQ.
     unsafe {
         core::arch::asm!("cli", options(nomem, nostack));
     }

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -26,6 +26,7 @@ fn panic(info: &PanicInfo) -> ! {
 
     // Halt all CPUs: disable interrupts, then halt in loop
     loop {
+        // SAFETY: cli; hlt — kernel panic, park CPU.
         unsafe {
             core::arch::asm!("cli; hlt", options(nomem, nostack));
         }

--- a/kernel/src/sync.rs
+++ b/kernel/src/sync.rs
@@ -58,12 +58,14 @@ pub struct SpinLockGuard<'a, T> {
 impl<'a, T> Deref for SpinLockGuard<'a, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
+        // SAFETY: SpinLockGuard's existence proves we hold the lock exclusively.
         unsafe { &*self.lock_ref.data.get() }
     }
 }
 
 impl<'a, T> DerefMut for SpinLockGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: see deref().
         unsafe { &mut *self.lock_ref.data.get() }
     }
 }

--- a/kernel/src/task/process.rs
+++ b/kernel/src/task/process.rs
@@ -93,6 +93,7 @@ impl UserProcess {
         //   would have us scribbling over someone else's stack. Mitigated by
         //   alloc_contiguous tracking and the guard page byte pattern that
         //   surfaces overflows on the next context switch.
+        // SAFETY: see the WHY/INVARIANT/FAILURE block above.
         unsafe {
             core::ptr::write_bytes(
                 alloc_base as *mut u8,
@@ -162,6 +163,7 @@ impl UserProcess {
             //   by the user-side path computing block_bytes_aligned before
             //   this loop and the caller (sys_spawn) capping argv at
             //   MAX_ARGS = 64.
+            // SAFETY: see the WHY/INVARIANT/FAILURE block above.
             unsafe {
                 *(virt_to_phys(sp) as *mut u8) = 0;
             }
@@ -174,6 +176,7 @@ impl UserProcess {
             //   The two ranges cannot overlap because the destination is
             //   user-virtual + identity-mapped, the source is kernel-heap.
             // FAILURE: same overflow story as above; mitigated the same way.
+            // SAFETY: see the WHY/INVARIANT/FAILURE block above.
             unsafe {
                 core::ptr::copy_nonoverlapping(
                     arg.as_ptr(),
@@ -240,6 +243,7 @@ impl UserProcess {
         //   leak unrelated stack content into the argc/argv view
         //   _start sees. Mitigated by the block_bytes formula matching the
         //   index arithmetic line-for-line.
+        // SAFETY: see the WHY/INVARIANT/FAILURE block above.
         unsafe {
             // argc at [rsp+0]
             *(virt_to_phys(user_rsp) as *mut u64) = argc as u64;
@@ -288,6 +292,7 @@ impl UserProcess {
         // FAILURE: a wrong frame layout (re-ordering RIP/CS/RFLAGS/RSP/SS)
         //   would IRETQ to a garbage RIP and triple-fault. Mitigated by
         //   matching the Intel SDM Vol 1 §6.14 order documented inline.
+        // SAFETY: see the WHY/INVARIANT/FAILURE block above.
         unsafe {
             let frame = iret_frame_start as *mut u64;
             // IRETQ pops: RIP, CS, RFLAGS, RSP, SS (in that order)
@@ -360,6 +365,7 @@ impl UserProcess {
             //   user code escalate. Mitigated by USER_CODE/USER_DATA flag
             //   selection above and by validate_user_ptr checks in the
             //   syscall path.
+            // SAFETY: see the WHY/INVARIANT/FAILURE block above.
             unsafe {
                 virt::map_range(
                     pml4_phys,

--- a/kernel/src/task/task.rs
+++ b/kernel/src/task/task.rs
@@ -137,6 +137,7 @@ impl Task {
         let stack_base = alloc_base + (KERNEL_STACK_GUARD_PAGES * phys::FRAME_SIZE) as u64;
         let stack_top = stack_base + KERNEL_STACK_SIZE as u64;
 
+        // SAFETY: freshly-allocated guard+stack pages, exclusively owned.
         unsafe {
             // Guard page: fill with sentinel byte so scheduler.check_kernel_stack_guard
             // can detect an overflow at the next context switch.
@@ -158,6 +159,7 @@ impl Task {
         // RSP points to where we've set up our fake stack frame
         // We push a return address (entry_fn) onto the stack
         let initial_rsp = stack_top - 8; // Space for the "return address"
+                                         // SAFETY: writing into top-of-stack we just allocated above.
         unsafe {
             // The trampoline will read RBX as the real entry function
             *(initial_rsp as *mut u64) = 0; // Dummy return address (task_entry_trampoline never returns)

--- a/kernel/src/tty/pty.rs
+++ b/kernel/src/tty/pty.rs
@@ -117,6 +117,7 @@ impl PtyMaster {
         self.winsize = WinSize { rows, cols };
         // Deliver SIGWINCH to slave's foreground process group
         if self.foreground_pgid > 0 {
+            // SAFETY: cli/sti window so SIGWINCH delivery to the pgid is atomic.
             unsafe {
                 core::arch::asm!("cli", options(nomem, nostack));
                 crate::task::scheduler::send_signal_to_group(
@@ -151,6 +152,7 @@ impl PtyMaster {
             TtySignal::Eof => return, // EOF is not a signal
         };
         if self.foreground_pgid > 0 {
+            // SAFETY: cli/sti window so the signal delivery is atomic.
             unsafe {
                 core::arch::asm!("cli", options(nomem, nostack));
                 crate::task::scheduler::send_signal_to_group(self.foreground_pgid as u32, signal);

--- a/kernel/src/tty/tty.rs
+++ b/kernel/src/tty/tty.rs
@@ -40,6 +40,7 @@ impl Tty {
         let changed = self.winsize.rows != rows || self.winsize.cols != cols;
         self.winsize = WinSize { rows, cols };
         if changed && self.foreground_pgid > 0 {
+            // SAFETY: cli/sti window so SIGWINCH delivery is atomic.
             unsafe {
                 core::arch::asm!("cli", options(nomem, nostack));
                 crate::task::scheduler::send_signal_to_group(

--- a/kernel/src/vfs/initramfs.rs
+++ b/kernel/src/vfs/initramfs.rs
@@ -230,6 +230,8 @@ impl Initramfs {
             if offset + data_len > data.len() {
                 break;
             }
+            // SAFETY: offset + data_len bounded by the offset check above; the
+            // slice borrows the static initramfs blob.
             let file_data: &'static [u8] =
                 unsafe { core::slice::from_raw_parts(data.as_ptr().add(offset), data_len) };
             offset += data_len;

--- a/kernel/src/vfs/pipe.rs
+++ b/kernel/src/vfs/pipe.rs
@@ -112,6 +112,7 @@ pub struct PipeReadEnd {
 
 impl Drop for PipeReadEnd {
     fn drop(&mut self) {
+        // SAFETY: shared SHM is owned by the pipe pair; Drop is exclusive.
         unsafe {
             self.shared
                 .get_mut()
@@ -167,6 +168,7 @@ pub struct PipeWriteEnd {
 
 impl Drop for PipeWriteEnd {
     fn drop(&mut self) {
+        // SAFETY: shared SHM is owned by the pipe pair; Drop is exclusive.
         unsafe {
             self.shared
                 .get_mut()

--- a/kernel/src/vfs/procfs.rs
+++ b/kernel/src/vfs/procfs.rs
@@ -262,6 +262,7 @@ impl ProcFileInode {
             INO_MOUNTS => {
                 // device mountpoint fstype options 0 0
                 let mut out = String::new();
+                // SAFETY: mount_table singleton initialised at boot.
                 unsafe {
                     let mt = super::mount::mount_table();
                     for m in mt.entries() {
@@ -288,6 +289,7 @@ impl ProcFileInode {
             INO_CACHESTATS => {
                 let mut out =
                     String::from("# mount hits misses cached_entries dirty_entries hit_rate%\n");
+                // SAFETY: mount_table singleton.
                 unsafe {
                     let mt = super::mount::mount_table();
                     for m in mt.entries() {
@@ -311,6 +313,7 @@ impl ProcFileInode {
                 // Block size is 512 B. Only racfs mounts report real numbers — other
                 // filesystems are reported as 0 since they aren't block-backed.
                 let mut out = String::from("# mount total_blocks used_blocks free_blocks total_inodes free_inodes (block=512B)\n");
+                // SAFETY: mount_table singleton.
                 unsafe {
                     let mt = super::mount::mount_table();
                     for m in mt.entries() {
@@ -411,6 +414,7 @@ impl ProcPidFileInode {
         match self.sub {
             1 => {
                 // status
+                // SAFETY: cli/sti window so the task-table read is consistent.
                 unsafe {
                     core::arch::asm!("cli", options(nomem, nostack));
                     let info = crate::task::scheduler::with_task_by_pid(self.pid, |t| {
@@ -440,6 +444,7 @@ impl ProcPidFileInode {
             }
             2 => {
                 // cmdline
+                // SAFETY: cli/sti window so the task-table read is consistent.
                 unsafe {
                     core::arch::asm!("cli", options(nomem, nostack));
                     let result = crate::task::scheduler::with_task_by_pid(self.pid, |t| {

--- a/kernel/src/vfs/racfs.rs
+++ b/kernel/src/vfs/racfs.rs
@@ -328,14 +328,17 @@ impl Racfs {
     }
 
     fn cache_mut(&self) -> &mut BlockCache {
+        // SAFETY: racfs is single-CPU MVP; callers run inside their own syscall.
         unsafe { &mut *self.cache.get() }
     }
 
     fn sb(&self) -> &Superblock {
+        // SAFETY: see cache_mut().
         unsafe { &*self.sb.get() }
     }
 
     fn sb_mut(&self) -> &mut Superblock {
+        // SAFETY: see cache_mut().
         unsafe { &mut *self.sb.get() }
     }
 

--- a/kernel/src/vfs/tmpfs.rs
+++ b/kernel/src/vfs/tmpfs.rs
@@ -72,18 +72,23 @@ impl Tmpfs {
     }
 
     fn nodes(&self) -> &Vec<TmpfsNode> {
+        // SAFETY: tmpfs is single-CPU MVP; mutators take exclusive access via CLI/STI
+        // at syscall entry, readers only run during their own syscall.
         unsafe { &*self.nodes.get() }
     }
 
     fn nodes_mut(&self) -> &mut Vec<TmpfsNode> {
+        // SAFETY: see nodes().
         unsafe { &mut *self.nodes.get() }
     }
 
     fn total_bytes(&self) -> usize {
+        // SAFETY: see nodes().
         unsafe { *self.total_bytes.get() }
     }
 
     fn set_total_bytes(&self, v: usize) {
+        // SAFETY: see nodes().
         unsafe {
             *self.total_bytes.get() = v;
         }


### PR DESCRIPTION
## 🎉 Milestone: T4.2 backlog COMPLETE

Final §3.3 unsafe-block annotation sweep. **Closes the remaining 28 files, each to 0 missing**, taking the kernel + libs total from 75 missing to **0**.

\`bash scripts/check-unsafe-safety.sh --strict\` now **passes clean** and is ready to be flipped on as a CI gate.

\`\`\`
$ bash scripts/check-unsafe-safety.sh
scanned 456 unsafe blocks under kernel/ + libs/; 0 missing SAFETY

$ bash scripts/check-unsafe-safety.sh --strict
scanned 456 unsafe blocks under kernel/ + libs/; 0 missing SAFETY
\`\`\`

## Files closed by this sweep

Top files (≥4 blocks):
- \`task/process.rs\` (6 → 0) — long-form WHY/INVARIANT/FAILURE blocks already documented the rationale; added terse "see block above" SAFETY refs to land in the lint's 5-line window.
- \`vfs/procfs.rs\` (5 → 0) — mount_table singleton, cli/sti task-table reads.
- \`fb_console.rs\` (5 → 0) — framebuffer copy/clear, FB_CONSOLE singleton.
- \`vfs/tmpfs.rs\` (4 → 0) — UnsafeCell deref on single-CPU MVP.
- \`mm/phys.rs\` (4 → 0) — FRAME_ALLOCATOR singleton accessors.
- \`mm/heap.rs\` (4 → 0) — free-list pointer manipulation.
- \`drivers/pci.rs\` (4 → 0) — PCI CF8/CFC port I/O.
- \`arch/mod.rs\` (4 → 0) — CPUID, CR4 SMEP/SMAP, halt.
- \`arch/lapic.rs\` (4 → 0) — LAPIC register MMIO with base check.

Smaller files (each → 0):
\`vfs/racfs.rs\` (3), \`drivers/block.rs\` (3), \`arch/smp.rs\` (3), \`arch/gdt.rs\` (3), \`task/task.rs\` (2), \`sync.rs\` (2), \`net/stack.rs\` (2), \`tty/pty.rs\` (2), \`vfs/pipe.rs\` (2), \`interrupts/pic.rs\` (2), \`arch/acpi.rs\` (1), \`arch/percpu.rs\` (1), \`drivers/mod.rs\` (1), \`drivers/ps2_keyboard.rs\` (1), \`interrupts/pit.rs\` (1), \`mm/virt.rs\` (1), \`mod_loader.rs\` (1), \`net/mod.rs\` (1), \`panic.rs\` (1), \`tty/tty.rs\` (1), \`vfs/initramfs.rs\` (1).

## Patterns documented

- Kernel-singleton accessors (\`SCHEDULER\`, \`FRAME_ALLOCATOR\`, \`LAPIC_BASE\`, \`ACPI_INFO\`, \`MODULE_MANAGER\`, \`NET_STATE\`, \`FB_CONSOLE\`, \`mount_table\`, \`racfs::instance\`, \`tmpfs::instance\`).
- cli/sti scheduler windows.
- MMIO/PIO at architectural ports.
- Freshly-allocated-frame writes (exclusively owned).
- cpuid/cr4/cr2/rdtsc/hlt/lgdt/ltr inline asm.
- SpinLockGuard exclusive ownership of UnsafeCell.
- Drop-time pipe close stores.
- Exception/IRQ handler entries.

## T4.2 session total

| Stage | Missing |
|---|---|
| Start of T4.2 sweep effort | 350 |
| After PR #19 (handlers first pass) | 323 |
| After PR #20 (handlers second pass) | 295 |
| After PR #22 (libc-lite first pass) | 266 |
| After PR #21 (handlers third pass) | 240 |
| After PR #24 (libc-lite second pass) | 211 |
| After PR #23 (handlers fourth pass) | 175 |
| After PR #25 (libc-lite third pass) | 156 |
| After PR #26 (main.rs) | 120 |
| After PR #27 (drivers + scheduler) | 75 |
| After PR #28 (sweep elf/fat32/vt/idt) | 75 |
| **After this PR** | **0** |

10 merged PRs + this one closes the backlog. **456 unsafe blocks scanned, all annotated.**

## Build

\`\`\`
$ cargo build -p racore --target x86_64-unknown-none
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 2.75s
\`\`\`

Pure comments-only kernel change. No functional behaviour modified.

## Next: flip lint to CI gate

The §3.3 ROADMAP item said *"Flip the lint to a CI gate (probably \`continue-on-error: true\` first, then mandatory) once the count clears 50."* It's at zero now — that flip is ready any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)