### PR TITLE
T4.2 cigate: flip unsafe-safety lint from advisory to required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,16 +494,15 @@ jobs:
   unsafe-safety:
     # Enforces ARCHITECTURE.md §3.3: every `unsafe {` block under kernel/
     # and libs/libc-lite must have a `// SAFETY:` comment in the preceding
-    # 5 lines. The backlog cleared in T4.2 (10 sweep PRs, 350 → 0); from
+    # 5 lines. The backlog cleared in T4.2 (12 sweep PRs, 350 → 0); from
     # this point on the lint is the only thing keeping us at 0.
     #
-    # Starts as advisory (continue-on-error: true) for one cycle so any
-    # toolchain weirdness around the bash script can surface without
-    # blocking merges; flip to required after the first clean green run.
+    # Required gate: the advisory cycle on PR #30 passed in 8s, so we're
+    # promoting it to mandatory now. Re-adding `unsafe {` without SAFETY
+    # in the preceding 5 lines will block the PR.
     name: Unsafe-safety annotation lint (--strict)
     runs-on: ubuntu-latest
     needs: build
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Run check-unsafe-safety.sh --strict


### PR DESCRIPTION
## Summary

One-line follow-up to PR #30: drop \`continue-on-error: true\` from the \`Unsafe-safety annotation lint (--strict)\` job. The advisory cycle ran clean on PR #30 (8 seconds, all 456 blocks accounted for), so promoting to a required gate now.

## Why

- The §3.3 backlog is at 0 (PR #29).
- The lint already ran clean in CI once (PR #30, 8s).
- Without enforcement, the next \`unsafe {\` added in a PR would silently break the invariant.

## Diff

\`\`\`yaml
 jobs:
   unsafe-safety:
     # ...
     name: Unsafe-safety annotation lint (--strict)
     runs-on: ubuntu-latest
     needs: build
-    continue-on-error: true
     steps:
\`\`\`

## Test

\`\`\`
$ bash scripts/check-unsafe-safety.sh --strict
scanned 456 unsafe blocks under kernel/ + libs/; 0 missing SAFETY
$ echo \$?
0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)