### PR TITLE
T4.3 second pass + CHANGELOG.md introduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,136 @@
+# Changelog
+
+All notable changes to RacOS are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Pre-1.0 entries describe development progress relative to the tiered plan in
+[`docs/ROADMAP.md`](docs/ROADMAP.md). Each entry references the merged PRs and
+the architectural sub-task IDs (T1.x, T2.x, …) that motivated it.
+
+## [Unreleased]
+
+### Added
+- Nothing yet.
+
+## [0.1.0] — 2026-06-16
+
+First public development milestone. Two largest backlog items from §Decision
+in the ADRs (the unsafe-block audit and the userland stub set) are closed; the
+shell scripting and service manager foundations are in place; the network
+stack is end-to-end on IPv4; persistence works across reboots via AHCI; the
+build cross-compiles on Ubuntu / Windows / macOS.
+
+### Added — Tier 1 (chokepoints)
+
+- **T1.1 — User-mode signal delivery** (PR #6). `sys_sigaction` installs a
+  cooked handler, the kernel pushes a `UserSignalFrame` on the user stack and
+  redirects RIP to libc-lite's `__signal_dispatcher`; `sys_sigreturn` restores
+  the pre-signal context. Covered by `racos-test::PHASE21-USER-HANDLER-OK`
+  and `PHASE21-USER-HANDLER-REENTRANT-OK`.
+- **T1.2 — Shell scripting in racsh**. Runtime for `if`/`while`/`for`/`case`,
+  parameter expansion (`$?`, `$0..$9`, `${VAR:-default}`, `${#VAR}`, …),
+  `source` / `.` builtin, `sh script.sh` from a file, IFS-based field
+  splitting. Smoke `T12-SHELL-CONTROL-FLOW-OK`.
+- **T1.3 — RacInit engine wired to PID 1**. Unit file parser
+  (`.service`/`.target`/`.timer`/`.mount`/`.device`), Kahn topological sort
+  with cycle detection, restart policies plus 5-in-30s burst limit. Default
+  unit files `base.target` + `shell.service` ship in the initramfs. Falls
+  back to the legacy spawn-shell loop when no unit files are present. 13
+  host tests plus the `T13-INIT-ENGINE-OK` QEMU smoke.
+
+### Added — Tier 2 (developable OS)
+
+- **T2.1 — Persistence in CI**. boot-smoke now attaches a 16 MiB AHCI disk
+  (`ich9-ahci`) and boots QEMU twice — first boot formats the disk and writes
+  a `boot-counter`, second boot reads it back as 1 and increments to 2.
+  `kernel/src/main.rs` mounts racfs at `/mnt`. `flushd` writeback daemon
+  flushes dirty block-cache entries on every block-backed mount.
+- **T2.2 — RacTerm ANSI emulator** (already implemented at 1616 lines pre-
+  T2.2): 31 host tests in `terminal/tests/ansi.rs` cover the CSI parser,
+  cursor movement, SGR colours, alternate buffer, DECTCEM, DECSTBM, DSR,
+  scrollback, OSC 0 title. Fixed: `Terminal::drain_response()` is now called
+  in racterm's main PTY loop so DSR / DA replies actually reach the shell.
+- **T2.3 — Cross-platform build**. `scripts/run-ci-smoke.sh` (bash port of
+  the PS smoke runner), `just smoke` / `just smoke-disk` recipes routed by
+  `[unix]` / `[windows]` attributes, `docs/DEVELOPMENT_LINUX.md`.
+
+### Added — Tier 3 (toward v1.0)
+
+- **T3.1 — SMP**. AP bring-up via INIT-SIPI-SIPI from `arch::ap::bring_up_all`
+  with a real-mode → protected → long-mode trampoline. Each AP loads the
+  kernel GDT/IDT, enables its LAPIC, binds GS to its PerCpu slot, starts its
+  own LAPIC timer. `/proc/cpuinfo` enumerates online CPUs.
+  CI runs QEMU with `-smp 4` and grep-gates the enumeration logs.
+- **T3.2 — rpkg MVP**. End-to-end install/list/remove CLI in
+  `pkg/rpkg-bin/`. Writes to `/var/lib/rpkg/info/<name>/`; tracks installed
+  files for clean removal. Smoke `T32-RPKG-OK`.
+- **T3.3 — Userland: ps + sed + env + awk**. Each binary rewritten from a
+  dead-code stub (wrong libc-lite path, missing `alloc` feature, not in
+  workspace, missing from BIN_LIST) into a working MVP with a racos-test
+  smoke marker: `T33-PS-OK`, `T33-SED-OK`, `T33-ENV-OK`, `T33-AWK-OK`.
+  awk supports `BEGIN`/`{}`/`END` blocks, `$0..$N` fields, `-F` separator,
+  literal strings, comma-separated print items.
+
+### Added — Tier 4 (strategic)
+
+- **T4.2 — Unsafe-block audit (BACKLOG COMPLETE)**. 391 `// SAFETY:`
+  annotations added across 12 sweep PRs (#18 – #29) reducing the missing
+  count from 350 → 0. Every `unsafe {` block under `kernel/` and
+  `libs/libc-lite/` now has a `// SAFETY:` comment in the preceding 5 lines.
+  `scripts/check-unsafe-safety.sh --strict` passes clean. CI gate
+  `Unsafe-safety annotation lint (--strict)` was promoted from advisory to
+  required in PR #31.
+- **T4.3 — ADR/spec resync, second pass**. Implementation-status sections
+  added to ADR-009 (VFS — 6 filesystems mounted, racsysfs collapsed into
+  procfs), ADR-011 (init/service manager — engine shipped, servicectl
+  deferred), ADR-013 (logging — serial shipped, journal deferred), ADR-018
+  (repository signing — package format shipped, signing waits on T4.1
+  crypto), ADR-019 (security baseline — DAC + caps + SMEP/SMAP + NX
+  shipped; ASLR + seccomp + secure-boot deferred). First pass covered
+  ARCHITECTURE.md §1.3 + ADRs 003/006/007/008.
+
+### Changed
+
+- `kernel/src/main.rs`'s crate-level discipline comment was rephrased to
+  stop triggering a false positive in the `check-unsafe-safety.sh` regex.
+- `racterm` and `init` were added to the host-side `cargo test` set so the
+  31 ANSI tests + 13 engine tests run on every PR.
+
+### Fixed
+
+- racterm's PTY relay never called `Terminal::drain_response()`, so DSR
+  (`\e[6n`) and DA (`\e[c`) replies queued in the emulator never reached the
+  shell. ncurses-style apps that waited for the reply would hang.
+- `RacInit::resolve_start_order` had a buggy Kahn's-algorithm implementation
+  that lost edges across iterations; rewritten with a proper in-degree
+  decrement and a separate cycle-detection pass.
+- `/bin/ps` looped `getdents` expecting a cursor that the kernel API
+  doesn't have, returning duplicate rows. Single-call read fixes it.
+- The userland stub binaries (`ps`, `sed`, `env`, `awk`) all had the same
+  four wiring bugs (libc-lite path, `alloc` feature, workspace member, two
+  BIN_LIST entries in the build scripts). Each was fixed in its T3.3
+  rewrite PR.
+- AHCI persistence in boot-smoke had two earlier flakes: `-drive if=ide`
+  didn't surface as `sda` on q35, and `fat:rw:esp` auto-FAT occasionally
+  produced an unbootable ESP on the second QEMU run. Now uses an explicit
+  `ich9-ahci` controller and a pre-baked 256 MiB FAT32 ESP image.
+- LAPIC MMIO register access was unaligned; switched to `read_volatile` /
+  `write_volatile` at the documented 16-byte register offsets.
+
+### Security
+
+- The unsafe-block audit (T4.2) makes every cross-ring memory access in
+  the kernel inspectable: the `// SAFETY:` comment names the invariant
+  (kernel singleton, cli/sti window, validate_user_ptr-bounded, etc.) so
+  reviewers don't have to reconstruct it from the surrounding code.
+- New CI gate `Unsafe-safety annotation lint (--strict)` blocks PRs that
+  add `unsafe {` without a SAFETY note in the preceding 5 lines.
+- `sys_reboot` is gated on `CAP_SYS_BOOT`; `sys_mount` / `sys_umount` /
+  `sys_mkfs` on `CAP_SYS_ADMIN`; `sys_chown` on `CAP_CHOWN`; `sys_setuid`
+  / `sys_setgid` consult `CAP_SETUID` / `CAP_SETGID` (verified by
+  `racos-test::test_security_syscalls`).
+
+[Unreleased]: https://github.com/RaCzKoViC/RacOS/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/RaCzKoViC/RacOS/releases/tag/v0.1.0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -181,7 +181,9 @@ Ten dokument jest źródłem prawdy o kierunku rozwoju RacOS. Każda większa pr
   - **ADR-007 (scheduler MVP)** — added implementation status: PR #14 shipped AP bring-up, per-CPU GS + LAPIC timers, `/proc/cpuinfo` enumeration, CI `-smp 4`. Per-CPU run queues + IPI preemption still on the scheduler-refactor TODO.
   - **ADR-008 (memory model)** — added note: huge pages stay kernel-internal (identity map only), CoW is still TODO so every `sys_fork` pays a full page-table-copy cost.
   - Lighter check on ADRs 001/002/004/005/009-013/015-020 didn't surface blatant drift.
-  - **Pozostałe (deferred):** sample ADRs 009/011/013/018/019 deeper once the relevant subsystems get follow-up work. `CHANGELOG.md` introduction still pending.
+  - **Second pass:** Implementation-status sections added to ADR-009 (VFS — 6 filesystems mounted, racsysfs collapsed into procfs, no separate dentry cache), ADR-011 (RacInit engine shipped at PID 1; servicectl/.timer/socket activation deferred), ADR-013 (boot-time serial logging shipped, journal/log-levels deferred), ADR-018 (rpkg format shipped; Ed25519 signing gated on T4.1 crypto), ADR-019 (DAC + caps + SMEP/SMAP + NX + validate_user_ptr shipped; ASLR/seccomp/secure-boot deferred).
+  - **CHANGELOG.md** introduced at repo root in Keep-a-Changelog format with the v0.1.0 milestone seeded from the merged PR history (Tier 1-4 entries, Added/Changed/Fixed/Security categories).
+  - **Pozostałe (deferred):** ADR-009 racsysfs decision (drop or add as an ADR amendment), ADR-013 once a real journal exists, ADR-018 once T4.1 crypto lands.
 
 ---
 

--- a/docs/adr/ADR-009-vfs-model.md
+++ b/docs/adr/ADR-009-vfs-model.md
@@ -51,3 +51,28 @@ VFS dispatches operations to registered filesystem implementations.
 ## Rollback
 
 Individual filesystem implementations can be replaced without changing VFS or syscall layer.
+
+## Implementation status (2026-06-16)
+
+The VFS layer is in place and load-bearing. Most of §Decision is shipped; the racprocfs vs racsysfs split was collapsed into procfs-only.
+
+**Shipped:**
+* `Inode` + `OpenFile` + `FdTable` + `mount_table` singleton in `kernel/src/vfs/`. Operations dispatched through the `Filesystem` and `InodeOps` traits.
+* Path resolution via `mount_table().resolve()` (longest-prefix match) and per-FS `lookup_path` — no separate dentry cache; the per-FS implementations cache their own metadata where it helps (`racfs::metadata_cache`, `fat32::metadata_cache`).
+* Five built-in filesystems mounted at boot from `kernel/src/main.rs:217-318`:
+  - **initramfs** at `/` (read-only, from the bootloader-supplied binary blob)
+  - **devfs** at `/dev` (`/dev/null`, `/dev/zero`, `/dev/console`)
+  - **tmpfs** at `/tmp` (in-memory R/W)
+  - **procfs** at `/proc` (`status`, `cmdline`, `cpuinfo`, `uptime`, `mounts`, `cachestats`, `diskstats`)
+  - **racfs** at `/var` (ramdisk-backed, ephemeral)
+* Two extra filesystems mounted opportunistically:
+  - **fat32** at `/fat` (volatile, formatted fresh each boot on ram1) — `kernel/src/main.rs:296`
+  - **racfs** at `/mnt` (persistent, on AHCI sda) — `kernel/src/main.rs:322`
+* Block device abstraction in `kernel/src/drivers/block.rs`; AHCI driver in `drivers/ahci.rs`; two-boot persistence smoke in CI (T2.1).
+* `sys_mount` / `sys_umount` / `sys_mkfs` accept user-space mount requests for tmpfs/racfs/proc/dev/fat32, gated on `CAP_SYS_ADMIN`.
+
+**Still deferred / different from §Decision:**
+* **racsysfs** was never built. `/sys` doesn't exist; the system-info bits §Decision put under racsysfs ended up in procfs (cpuinfo, uptime, etc.).
+* No separate dentry cache. The hash-map design from §Decision was replaced by per-FS metadata caches plus mount-table resolution, which is faster for the current small-tree workload but doesn't help directory lookups across mount points.
+* racfs journaling is still deferred — racfs writes superblock + extent allocator updates directly. The kernel-side flushd daemon (T2.1, `kernel/src/main.rs:351-362`) flushes dirty cache entries periodically as a partial mitigation.
+* FAT32 supports R/W but the on-disk dir-walk has a cycle guard added after a chase bug — a real journal is post-MVP.

--- a/docs/adr/ADR-011-init-service-manager.md
+++ b/docs/adr/ADR-011-init-service-manager.md
@@ -35,3 +35,24 @@ Key properties:
 ## Rollback
 
 Replacing RacInit requires writing a new init that conforms to the kernel's PID 1 expectations (receives orphans, handles signals). Unit file format is independent.
+
+## Implementation status (2026-06-16)
+
+The engine shipped in T1.3. RacInit runs as PID 1 with a real dependency graph and restart policy; `servicectl` and socket activation are still deferred.
+
+**Shipped:**
+* Unit file parser for `.service` / `.target` / `.timer` / `.mount` / `.device` in `init/src/lib.rs`. Round-trip tested by host suite `init/tests/engine.rs`.
+* Dependency resolution via Kahn's topological sort with cycle detection — `Engine::resolve_start_order` returns `ResolveResult { order, cycle }`; cycles, self-edges, linear, and diamond graphs are all covered by host tests.
+* Restart policies (`no` / `on-failure` / `on-abnormal` / `always`) plus a burst limiter: 5 restarts within a 30-second window flips the unit to `Failed`. Window-decay tracker is host-tested.
+* Wired to PID 1 in `userland/coreutils/init/main.rs` — the engine path runs if `/etc/racinit/units/` has any unit files; falls back to the legacy spawn-shell loop otherwise.
+* Default unit files shipped in `initramfs-root/etc/racinit/units/`: `base.target` + `shell.service` (`Restart=always`).
+* Orphan reparenting + SIGCHLD delivery in `kernel/src/task/scheduler.rs:exit_current`; verified by `racos-test::test_sigchld_waitpid` (PHASE21-SIGCHLD-WAIT-OK).
+* CI smoke `T13-INIT-ENGINE-OK` boots the engine path in QEMU and asserts the shell came up.
+* SIGTERM → SIGKILL escalation is delivered through the existing signal queue (`sys_kill` → `send_signal_to`); per-unit timeout enforcement is not wired yet.
+
+**Still deferred:**
+* **`servicectl` CLI** — spec lives in `ARCHITECTURE.md §8.4` but no userland binary exists. Operational visibility today is via `serial` logs only.
+* **`.timer` scheduling** — units parse but the engine doesn't have a clock-tick driver to fire them.
+* **Socket activation** — still post-MVP per §Decision.
+* **Per-unit log routing** — RacInit doesn't capture child stdout/stderr into journal files (see ADR-013 status).
+* **Per-unit timeout enforcement** — there's no watchdog that turns a hung start into SIGTERM+SIGKILL. Services run forever once spawned; the existing init watchdog (`kernel/src/main.rs:534`) only catches early crashes of PID 100 (the boot init).

--- a/docs/adr/ADR-013-logging-journaling.md
+++ b/docs/adr/ADR-013-logging-journaling.md
@@ -38,3 +38,21 @@ System logging is essential for debugging, monitoring, and incident response. Th
 ## Rollback
 
 Switching to binary journal format can be done transparently from RacInit's perspective by changing the journal writer module.
+
+## Implementation status (2026-06-16)
+
+Boot-time logging is shipped; the runtime/journal half is still spec-only. The current state covers debugging end-to-end via serial, which is enough for the v0 development loop but not for an operator running the system.
+
+**Shipped:**
+* Serial output on COM1 at 115200 baud — `kernel/src/serial.rs`. Bit-for-bit ordering preserved (no buffering races) because writes are guarded by `cli/sti` around `outb`. The serial subsystem also handles input IRQ (Ctrl-C → SIGINT on the foreground PG) in `serial::handle_irq`.
+* `println!` and `serial_println!` macros for component-tagged output. Format used in practice: `[ COMPONENT ] message` (e.g. `[  SCHED  ]`, `[ USERPROC ]`, `[ AHCI ]`, `[ SYSCALL ]`). The §Decision-prescribed `[timestamp] COMPONENT: message` was not adopted because the kernel doesn't have wall-clock time yet (RTC is a TODO); timestamps would only be uptime-since-PIT-init, and that turned out to clutter the log without adding value for the current debug workflow.
+* Boot-time log is also pushed to the framebuffer console (`tty/vt.rs` + `fb_console.rs`).
+* No kernel ring buffer yet — output goes straight to serial and framebuffer. CI relies on capturing the full serial log to a file, which makes a ring buffer redundant for tests; it'll be needed when a real `dmesg` syscall is added.
+
+**Still deferred:**
+* **Structured timestamps** — `[timestamp]` prefix is omitted because there's no RTC source. Once T4.x adds CMOS-RTC reads, the macro can be upgraded crate-wide without touching call sites.
+* **Log levels** (EMERG/CRIT/ERR/WARN/INFO/DEBUG/TRACE) — not implemented. Today, severity is encoded informally in the component prefix (e.g. `[FAIL]` vs `[PASS]` in racos-test, `!!!` for panics). A real `log!(level=...)` macro would let CI filter on level instead of grepping prefixes.
+* **`/var/log/racinit/` journal files** — RacInit doesn't capture service stdout/stderr (see ADR-011 status). Service output goes straight to the foreground TTY today.
+* **Rotation** — N/A while there's no journal to rotate.
+* **Binary journal format** — pre-rotation, pre-journal. Plain text is fine for v0.
+* **`servicectl log`** — depends on `servicectl` (see ADR-011 status) plus the journal capture above.

--- a/docs/adr/ADR-018-repository-signing.md
+++ b/docs/adr/ADR-018-repository-signing.md
@@ -43,3 +43,22 @@ Packages must be distributed through repositories with integrity verification. U
 ## Rollback
 
 Signing algorithm can be upgraded by adding new key type support alongside Ed25519.
+
+## Implementation status (2026-06-16)
+
+Package format ships (T3.2); signing and the repository protocol are both still spec-only — both gated on having a crypto stack, which is being built out in T4.1.
+
+**Shipped:**
+* Package format in `pkg/rpkg/` — header + sections + manifest TOML parser + files-list serializer.
+* CLI in `pkg/rpkg-bin/` (`/bin/rpkg install|list|remove`) — writes payloads to `/var/lib/rpkg/info/<name>/` and tracks installed files for clean removal. Smoke `T32-RPKG-OK` builds a `.rpk` in memory, installs/lists/removes it round-trip.
+* `rapt` skeleton (host-side dependency planner) — `pkg/rapt/`.
+
+**Still deferred (everything from §Decision and §Signing):**
+* **`/etc/rapt/sources.toml`** — no on-disk repository config; `rapt` doesn't read from a network mirror yet.
+* **Repository `index.toml`** — no signed index format, no fetcher.
+* **Ed25519 signatures** — no crypto in tree. Once T4.1 lands ChaCha20-Poly1305 + Ed25519 (the same crypto stack TLS needs), signing can be wired here. Package manifests already have the field hooks for a `signature` block; today rpkg accepts unsigned packages because `allow_unsigned = true` is the implicit default.
+* **Trusted keys at `/etc/rapt/keys/`** — directory is not created at install time.
+* **Channels** (stable/testing/dev) — there's no repository to channel.
+* **Mirror support / channel pinning** — both are post-§Decision-MVP from the start.
+
+This ADR's §Risks section is essentially the post-MVP TODO list for T4.1 + a follow-up repository PR.

--- a/docs/adr/ADR-019-security-baseline.md
+++ b/docs/adr/ADR-019-security-baseline.md
@@ -45,3 +45,29 @@ Security must be designed from the start, not bolted on later. RacOS needs a bas
 ## Rollback
 
 Individual mechanisms can be toggled via kernel config and unit file settings. Relaxing defaults is possible but requires ADR.
+
+## Implementation status (2026-06-16)
+
+About half of §Decision's mechanisms-enabled-by-default are shipped. Capabilities + DAC + SMEP/SMAP + NX are real and tested; signature verification, secure boot, ASLR, and seccomp are still TODO.
+
+**Shipped:**
+* **DAC** — `kernel/src/security/dac.rs::can_access` enforces owner/group/other RWX bits with the file's `uid`/`gid` against the caller's `Credentials`. Wired into every path-aware syscall (mkdir/unlink/rename/chmod/chown/open/access) via `require_dac_access`.
+* **Capability model** — `kernel/src/security/capability.rs`. Bitmask of `cap_permitted` / `cap_effective` / `cap_inheritable` on every `Task`. Capabilities defined and used: `CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETUID`, `CAP_SETGID`, `CAP_CHOWN`, `CAP_SYS_ADMIN`, `CAP_SYS_BOOT`. `racos-test::test_security_syscalls` proves the gates (CAP_SETUID denies non-cap callers, CAP_DAC_OVERRIDE lets a cap-effective process write a 0644 file it doesn't own).
+* **Per-process credentials** — `Task::creds` snapshotted on fork/clone/exec; new processes inherit parent's `Credentials::root()` for now (PID 1 boots as root).
+* **SMEP + SMAP** — enabled in `arch::enable_smep_smap` (`kernel/src/arch/mod.rs:128`) gated on CPUID.7:EBX. The syscall entry stub wraps the dispatcher in STAC/CLAC so handlers can touch validated user buffers; everywhere else in ring 0 is blocked from touching user memory by SMAP.
+* **NX (no-execute)** — `kernel/src/mm/virt.rs` sets the NX bit on data/BSS/stack mappings (`USER_DATA & !WRITABLE` for RO data, `USER_DATA` for RW, `USER_CODE` for executable text only).
+* **User-pointer validation** — `validate_user_ptr` + `validate_user_string` bound every syscall argument that crosses the ring boundary. Result is annotated in every `// SAFETY:` comment under `kernel/src/syscall/handlers.rs` (T4.2).
+* **Per-process FD table** — `Task::fd_table`; close-on-exec where set; FDs don't leak across `sys_exec`.
+* **Capabilities required for risky ops** — `sys_mount`/`sys_umount`/`sys_mkfs` require `CAP_SYS_ADMIN`; `sys_reboot` requires `CAP_SYS_BOOT`; `sys_chown` requires `CAP_CHOWN`.
+
+**Still deferred:**
+* **Package signature verification** — gated on crypto (see ADR-018 status). Today `rpkg install` accepts unsigned `.rpk` files.
+* **Stack protector** — Rust's overflow-check on debug builds catches integer overflow into UB; the `-Z stack-protector` flag isn't passed yet because the kernel uses a custom stack-guard sentinel (per-task `KERNEL_STACK_GUARD_BYTE`, checked on every context switch — see `task/scheduler.rs:check_kernel_stack_guards`) which is stricter than the LLVM canary approach and works for kernel stacks specifically.
+* **Mount flags** (noexec/nosuid/nodev) — `sys_mount` parses a `flags` argument but the kernel doesn't enforce per-mount restrictions yet. Today every mount is effectively `rw,suid,exec,dev`.
+* **Crash dump sanitization** — there's no crash-dump path; on panic the kernel prints the full register state to serial and halts. PID-namespacing isn't relevant since there are no namespaces.
+* **Syscall allowlist per service** (seccomp-like) — not in the engine, not in the kernel.
+* **ASLR for user space** — `process::from_elf` puts the user stack at a fixed `USER_STACK_TOP` and ET_DYN binaries at a fixed `ET_DYN_LOAD_BIAS`. No randomization source.
+* **Secure boot** — bootloader doesn't verify the kernel ELF signature; the UEFI image is signed by the firmware's chain but the kernel itself isn't.
+* **Dev-channel relaxation** — there's only one build channel today.
+
+The §Consequences "security is a compile-time and boot-time property" is half true: DAC + caps + SMEP/SMAP + NX + validate_user_ptr are all on by default and proven by tests. The signed-artifacts + seccomp + ASLR half is the T4.x roadmap.


### PR DESCRIPTION
## Summary

Closes the two T4.3 follow-ups that the first pass deferred (\`docs: sync ADR + ARCHITECTURE with shipped reality\`).

## ADR implementation-status sections

Five deferred ADRs now have an \`Implementation status (2026-06-16)\` section at the bottom, following the format from the first pass (ADR-007 etc.). Each section is split into **Shipped** (with file/line refs and PR pointers) vs **Still deferred** (with the gating reason).

| ADR | Title | Shipped | Deferred |
|---|---|---|---|
| 009 | VFS Model | 6 FS mounted (initramfs/devfs/tmpfs/procfs/racfs + fat32/mnt-racfs); block-device + AHCI; \`sys_mount\`/\`sys_umount\`/\`sys_mkfs\` | racsysfs (never built — system info moved to procfs); separate dentry cache (per-FS caches won); racfs journaling |
| 011 | RacInit | Engine wired at PID 1; unit parser + Kahn topo sort + cycle detection; restart policy + 5-in-30s burst; \`base.target\`+\`shell.service\` ship in initramfs; \`T13-INIT-ENGINE-OK\` smoke | \`servicectl\` CLI; \`.timer\` scheduling; socket activation; per-unit log routing; per-unit timeout enforcement |
| 013 | Logging / journaling | Serial COM1 + framebuffer; \`[ COMPONENT ] message\` format (no RTC means no timestamps) | Kernel ring buffer; log levels; \`/var/log/racinit/\` journal; rotation; binary journal; \`servicectl log\` |
| 018 | Repository signing | \`pkg/rpkg/\` + \`pkg/rpkg-bin/\` install/list/remove; \`T32-RPKG-OK\` smoke | Ed25519 signatures (gated on T4.1 crypto); \`/etc/rapt/sources.toml\`; \`index.toml\`; trusted keys; channels |
| 019 | Security baseline | DAC + capability model (CAP_DAC_OVERRIDE/SETUID/SETGID/CHOWN/SYS_ADMIN/SYS_BOOT) + SMEP/SMAP + NX + validate_user_ptr + per-process FD table; tested by \`test_security_syscalls\` | Package sig verification; LLVM stack protector (custom per-task kstack guard sentinel is stricter); mount flags noexec/nosuid/nodev; ASLR; seccomp-like allowlist; secure boot; crash-dump sanitization |

## CHANGELOG.md

New file at repo root in [Keep-a-Changelog](https://keepachangelog.com/en/1.1.0/) format:

- **Pre-1.0 \`[0.1.0]\` milestone** entry seeded from the merged PR history this cycle:
  - **Tier 1:** T1.1 signals → T1.2 racsh scripting → T1.3 RacInit engine
  - **Tier 2:** T2.1 persistence → T2.2 RacTerm ANSI → T2.3 cross-platform smoke
  - **Tier 3:** T3.1 SMP → T3.2 rpkg → T3.3 ps/sed/env/awk
  - **Tier 4:** T4.2 unsafe audit + CI gate; T4.3 ADR resync
- Categories: \`Added\` (per tier), \`Changed\`, \`Fixed\`, \`Security\`.
- References merged PRs and the smoke markers each test emits (\`PHASE21-*\`, \`T12-*\`, \`T13-*\`, \`T32-RPKG-OK\`, \`T33-{PS,SED,ENV,AWK}-OK\`).
- Compare/release links to GitHub.

## ROADMAP

T4.3 row updated with the new second-pass note + CHANGELOG status. T4.3 itself stays \`[x]\` (was already completed for the first pass).

## Verification

\`\`\`
\$ bash scripts/check-unsafe-safety.sh --strict
scanned 456 unsafe blocks under kernel/ + libs/; 0 missing SAFETY
\$ echo \$?
0
\`\`\`

Pure documentation change. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)