### PR TITLE
Quality+security sprint: SECURITY.md + DEPENDENCIES.md + coverage + audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,3 +507,64 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run check-unsafe-safety.sh --strict
         run: bash scripts/check-unsafe-safety.sh --strict
+
+  host-coverage:
+    # Advisory line-coverage for the host-testable crates (racsh + rpkg +
+    # rapt + init + racterm). The kernel, libc-lite, and userland binaries
+    # can't be measured this way — they target x86_64-unknown-none and run
+    # under QEMU, where llvm-cov can't attach. Their integration coverage
+    # comes from the QEMU smoke jobs above.
+    #
+    # Starts advisory (continue-on-error) so a transient cargo-llvm-cov
+    # toolchain issue doesn't block merges; flip to required once the
+    # baseline percentage stabilises.
+    name: Host coverage (advisory, llvm-cov)
+    runs-on: ubuntu-latest
+    needs: test-unit
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-05-21
+          components: rust-src, llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+      - name: Generate coverage
+        # Same test set as the test-unit job above; we just wrap it with
+        # cargo-llvm-cov so the percentage shows up in the workflow output.
+        run: cargo llvm-cov --workspace -p racsh -p rpkg -p rapt -p init -p racterm --summary-only
+      - name: Generate LCOV
+        run: cargo llvm-cov --workspace -p racsh -p rpkg -p rapt -p init -p racterm --lcov --output-path lcov.info
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: host-coverage-lcov
+          path: lcov.info
+          if-no-files-found: warn
+
+  cargo-audit:
+    # The kernel and every userland binary link zero third-party crates
+    # (see docs/DEPENDENCIES.md). Only the bootloader (`uefi` 0.34 +
+    # `log` 0.4) and host-side packaging tools (`pkg/rapt`, `pkg/rpkg`)
+    # could ever pull a vulnerable transitive dep. cargo-audit runs
+    # against Cargo.lock — even with mostly empty `[dependencies]` lists
+    # this is the right place to catch a RUSTSEC advisory before a PR
+    # lands. Advisory for one cycle; flip to required once it's been
+    # green-on-main for ~a week.
+    name: cargo-audit (advisory)
+    runs-on: ubuntu-latest
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-05-21
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Run cargo audit
+        # --deny warnings would block on yanked-but-not-vulnerable crates;
+        # we want to surface those without breaking CI. Real RUSTSEC
+        # advisories still fail the step.
+        run: cargo audit --deny unsound --deny unmaintained --deny notice

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,150 @@
+# Security Policy
+
+This document covers how to report vulnerabilities in RacOS, which
+versions receive security fixes, and what the project's security
+posture currently is.
+
+For the design baseline (which mechanisms are on by default, which are
+still being built), see [`docs/adr/ADR-019-security-baseline.md`](docs/adr/ADR-019-security-baseline.md).
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security reports.**
+
+Use either of:
+
+- GitHub's [private vulnerability reporting](https://github.com/RaCzKoViC/RacOS/security/advisories/new)
+  (preferred — keeps the discussion in-repo and creates an audit trail).
+- Email the maintainer directly via the address on the [@RaCzKoViC](https://github.com/RaCzKoViC)
+  GitHub profile.
+
+Include in the report:
+
+1. A description of the issue and the affected component(s).
+2. Steps to reproduce, ideally with a minimal test case (a userland
+   program, a script, a QEMU command line, or a kernel diff that
+   reliably triggers the bug).
+3. Your assessment of impact (information leak / privilege escalation /
+   denial of service / arbitrary code execution / etc.) and which
+   process boundary it crosses (user → kernel? user → user? bootloader
+   → kernel?).
+4. Any suggested fix or mitigation, if you have one.
+
+You should expect:
+
+- An acknowledgement within **72 hours** that your report was received
+  and is being looked at.
+- A status update within **14 days** with either a fix, a mitigation,
+  or a concrete plan + ETA.
+- A coordinated disclosure date once a fix is ready, normally **30
+  days** after the initial report (sooner if the fix is trivial and
+  already merged, longer for changes that need cross-subsystem work).
+- Credit in the release notes and `CHANGELOG.md` under the `Security`
+  section unless you ask to be omitted.
+
+## Supported versions
+
+RacOS is pre-1.0. Only `main` is supported for security fixes; there
+are no tagged release branches yet.
+
+Once `v1.0.0` ships, this section will list the supported semantic
+version ranges and the policy for backporting fixes.
+
+| Version | Supported |
+|---------|-----------|
+| `main`  | ✅ |
+| `< 1.0` snapshots | ❌ (use `main`) |
+
+## Scope
+
+The following are in-scope for the security policy:
+
+- Any path that lets a user-mode process gain kernel-mode execution.
+- Any path that lets a user-mode process bypass DAC, capability checks,
+  or the validate_user_ptr/`validate_user_string` boundary.
+- Any path that lets the bootloader hand off an unverified or malformed
+  kernel image without surfacing the failure on serial.
+- Information leaks across process boundaries (FDs, environment
+  variables, signal state, syscall return values).
+- Denial-of-service vulnerabilities that crash the kernel from a
+  user-mode caller.
+- Logic bugs in the package format (`rpkg`) that allow a malicious
+  `.rpk` to write outside `/var/lib/rpkg/info/<name>/` or to leave
+  partial files on disk after a failed install.
+- Bugs in the unit-file parser (`init/src/lib.rs`) that let a malicious
+  unit file crash PID 1.
+
+The following are **out-of-scope** for v0.x:
+
+- Side-channel attacks (Spectre, Meltdown, timing oracles, Rowhammer).
+  The kernel does not yet do any speculative-execution mitigations.
+- Attacks that require physical access (cold boot, DMA from a PCIe
+  card, firmware downgrade).
+- Attacks against the host system running QEMU.
+- Bugs that only manifest on hardware RacOS doesn't claim to support
+  (non-x86_64, non-UEFI).
+- Missing features documented as deferred in
+  [ADR-019 §Still deferred](docs/adr/ADR-019-security-baseline.md#implementation-status-2026-06-16):
+  ASLR, seccomp-like syscall allowlist, secure boot, signed `.rpk`
+  packages, mount-flag enforcement. These will be classified as
+  vulnerabilities once they're shipped and bypassable; today they're
+  open TODOs and don't qualify as security regressions.
+
+## Current security posture
+
+A snapshot. For the detailed list of what's enabled vs deferred, read
+[ADR-019's implementation-status section](docs/adr/ADR-019-security-baseline.md#implementation-status-2026-06-16).
+
+**Shipped and enforced:**
+
+- DAC (owner/group/other RWX) on every path-aware syscall.
+- Capability model: `CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETUID`,
+  `CAP_SETGID`, `CAP_CHOWN`, `CAP_SYS_ADMIN`, `CAP_SYS_BOOT`. Risky
+  syscalls (`mount`/`umount`/`mkfs`/`reboot`/`chown`/`setuid`/`setgid`)
+  are gated.
+- CPU mitigations enabled on every boot that supports them:
+  - **SMEP** — ring-0 can't execute user-mapped pages.
+  - **SMAP** — ring-0 can't read/write user-mapped pages without an
+    explicit `stac`/`clac` bracket (only the syscall entry stub takes
+    that bracket).
+  - **NX** — data, BSS, stack, and read-only data are mapped with the
+    no-execute bit.
+- Per-process FD table; FDs don't leak across `sys_exec`.
+- Per-task kernel-stack guard page with a sentinel byte checked on
+  every context switch — kernel-stack overflows are detected and
+  panic with the offending PID instead of corrupting another task.
+- `validate_user_ptr` / `validate_user_string` on every syscall
+  argument that crosses the ring boundary; the bounds check is the
+  documented invariant in every `// SAFETY:` annotation in
+  `kernel/src/syscall/handlers.rs` (every block annotated as part of
+  T4.2 — see `bash scripts/check-unsafe-safety.sh --strict`).
+- **Mandatory CI gate**: `Unsafe-safety annotation lint (--strict)`
+  refuses to merge PRs that add an `unsafe {` block without a
+  `// SAFETY:` comment in the preceding 5 lines.
+
+**Not yet enforced (won't be treated as vulnerabilities until shipped):**
+
+- Package signature verification (Ed25519). Gated on T4.1 crypto.
+- Mount flags (`noexec`, `nosuid`, `nodev`). The flag word is parsed
+  but the kernel doesn't enforce per-mount restrictions yet.
+- ASLR for user space. `process::from_elf` uses fixed
+  `USER_STACK_TOP` / `ET_DYN_LOAD_BIAS`.
+- Syscall allowlist per service (seccomp-like). No mechanism in the
+  engine or kernel.
+- Secure boot. The bootloader doesn't verify the kernel ELF
+  signature; the UEFI image is signed by the firmware's chain but the
+  kernel itself isn't.
+- Crash-dump sanitization. On kernel panic the full register state
+  goes straight to serial (there is no userland crash-dump path).
+
+## Public disclosure history
+
+No public vulnerabilities reported to date.
+
+Once reports are processed they will be listed here with:
+
+- CVE ID (if assigned)
+- Affected versions
+- Brief description
+- Link to the fix commit / PR
+- Reporter credit (if requested)

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,108 @@
+# Dependency Inventory
+
+Snapshot of every third-party crate that ends up in a shipped RacOS
+artifact. Updated whenever a new dependency is added.
+
+> Run `cargo tree --workspace --depth 2` for the live graph.
+
+## Summary
+
+| Component | External crates | Notes |
+|---|---|---|
+| `racore` (kernel) | **0** | Uses only `core` + `alloc` rebuilt by `-Z build-std`. `compiler_builtins` is provided by build-std. |
+| `racos-boot` (UEFI bootloader) | `uefi` 0.34, `log` 0.4 | UEFI services + the `log`-crate facade. |
+| `libs/libc-lite` (userland system library) | **0** | Pure `#![no_std]` inline-asm syscall wrappers. |
+| `libs/libcore-user` (userland helpers) | **0** | Pure `#![no_std]`. |
+| `userland/coreutils/*` | **0** (via `libc-lite`) | Every binary depends only on `libc-lite`. |
+| `userland/network/*` | **0** (via `libc-lite`) | Same. |
+| `shell` (racsh) | **0** | Pure `#![no_std]`. |
+| `terminal` (racterm) | **0** | Pure `#![no_std]` ANSI emulator. |
+| `init` (RacInit engine) | **0** | Pure `#![no_std]`. |
+| `pkg/rpkg` (package format lib) | **0** | Pure `#![no_std]`. |
+| `pkg/rpkg-bin` (`/bin/rpkg`) | **0** (via `libc-lite`) | |
+| `pkg/rapt` (host-side dep planner) | **0** | Pure host `std` Rust, no third-party. |
+
+**Total third-party crates shipped on the target: 2** (`uefi`, `log`).
+Both live only in the bootloader; the kernel and every userland
+artifact link zero external code.
+
+## Bootloader-only deps
+
+### `uefi` 0.34
+- Source: <https://github.com/rust-osdev/uefi-rs>
+- License: MPL-2.0
+- Why: UEFI services (`BootServices`, `RuntimeServices`, memory map,
+  graphics output protocol, file system protocol). Without it the
+  bootloader would have to hand-roll the UEFI calling convention and
+  GUID tables.
+- Features enabled: `alloc`, `global_allocator`.
+- Audit notes: the crate is maintained by rust-osdev, has an active
+  release cycle, and pins itself to UEFI 2.10. No `unsafe-impl-Send`
+  type smuggling in the version we link against (0.34).
+
+### `log` 0.4
+- Source: <https://github.com/rust-lang/log>
+- License: MIT OR Apache-2.0
+- Why: `uefi` 0.34 expects a `log` facade installed for its boot-services
+  diagnostics. We provide one that writes to serial via the
+  `simple_logger`-style adapter in `boot/src/`.
+- Audit notes: maintained by rust-lang. Zero internal `unsafe` in the
+  0.4 line; the version range is conservative (`= "0.4"`).
+
+## What we do not depend on
+
+Worth calling out because each of these is a typical kernel/OS
+dependency we explicitly avoided:
+
+- **`libc`** — replaced by `libs/libc-lite`, the in-tree no-std crate of
+  syscall wrappers. Doing it ourselves was easier than maintaining a
+  `libc` fork without `mmap`, `dlopen`, `__libc_start_main`, or the C
+  runtime's hidden global state.
+- **`spin` / `parking_lot`** — `kernel/src/sync.rs` is an in-tree
+  `SpinLock<T>` that fits the kernel's `cli/sti` invariants. No third
+  party.
+- **`bitflags`** — the kernel uses `const` bitmasks (page-table flags,
+  capability bits, FAT32 dir entries) without a macro layer.
+- **`linked_list_allocator` / `slab_allocator`** — `kernel/src/mm/heap.rs`
+  is a hand-rolled first-fit free-list allocator with coalescing. No
+  third party.
+- **`serde` / `serde_json` / `toml` (kernel side)** — the kernel uses
+  ad-hoc parsers for `procfs` output and `racfs` superblocks. Userland
+  `racinit` and `rpkg` use a 200-line in-tree TOML subset parser, not
+  the full `toml` crate.
+- **`x86_64` / `bootloader` / `multiboot2` / `volatile`** — kernel uses
+  raw inline asm, raw MMIO via `read_volatile`/`write_volatile`, and a
+  custom UEFI handoff convention with `racos-boot`. No third party.
+- **`async-std` / `tokio` / `embassy`** — no async runtime; the
+  scheduler runs synchronous kernel tasks.
+- **`crypto-*`** — there is no crypto in tree yet. T4.1 will bring in
+  ChaCha20-Poly1305, X25519, Ed25519, SHA-256, HKDF, and TLS 1.3
+  handshake code. Whether that lives in-tree or pulls a vetted crate
+  is an open ADR; the current preference (driven by the no-third-party
+  baseline) is in-tree from scratch.
+
+## Host-side tooling
+
+These are deps of `cargo test` on the host, not anything that ships:
+
+- `cargo` 1.x (workspace target builds)
+- `nightly-2026-05-21` pinned by `rust-toolchain.toml`
+- `nasm` (assembler for the AP trampoline)
+- `qemu-system-x86_64` + `OVMF` (CI smoke targets)
+- `mtools` + `python3` (ESP image staging on CI)
+
+None of these are linked into a shipped artifact.
+
+## Adding a new dependency
+
+Before adding a `Cargo.toml` `[dependencies]` entry:
+
+1. Check whether the in-tree approach is ~100 lines of Rust. If yes,
+   prefer in-tree (see the §"What we do not depend on" list for why).
+2. If a third-party crate is genuinely the right call (UEFI services,
+   future crypto), add a row to the §Summary table and a paragraph in
+   §Bootloader-only deps (or a new section).
+3. Note the crate's license, source URL, and whether it pulls in
+   transitive `unsafe`-heavy code (run `cargo geiger` if in doubt).
+4. Pin the version (`= "x.y"` rather than `^x.y`) — we'd rather take an
+   explicit upgrade PR than absorb a transitive bump silently.


### PR DESCRIPTION
## Summary

Short hygiene pass before the rapt package layer work. Four ergonomic improvements plus PR cleanup, all low-risk.

## What's in the PR

### \`SECURITY.md\` (new, repo root)
- **Reporting channel**: GitHub private vulnerability reporting preferred, email fallback via maintainer profile.
- **Disclosure timeline**: 72h ack → 14d status update → 30d coordinated disclosure (sooner for trivial fixes, longer for cross-subsystem work).
- **Scope**: explicitly lists what's in (kernel-boundary crossings, unit-file parser, rpkg writes outside its info dir, bootloader handoff) vs out (side channels, physical access, host-side QEMU, deferred features documented in ADR-019).
- **Current posture**: enumerates enforced mechanisms (DAC, capabilities, SMEP/SMAP/NX, validate_user_ptr, FD table, kstack guard, the new strict lint gate) vs not-yet-enforced (sigs, mount flags, ASLR, seccomp, secure boot, crash-dump sanitisation). Cross-links to ADR-019 so they're not double-tracked.

### \`docs/DEPENDENCIES.md\` (new)
- **Headline number**: \`racore\` (kernel) has **zero** external crate dependencies. The entire shipped target carries exactly **2 third-party crates** (\`uefi\` 0.34 + \`log\` 0.4), both bootloader-only.
- Summary table covering every workspace member.
- Per-dep section for the two bootloader deps with source URL, licence, why, audit notes.
- **\"What we do not depend on\"** list (libc, spin, bitflags, linked_list_allocator, serde, toml, x86_64 crate, async runtimes, crypto-*). Each row points to the in-tree alternative so future contributors don't reach for the dep by reflex.
- \"Adding a new dependency\" checklist: ~100-LOC test, table row, paragraph here, pinned version.

### CI: two new advisory jobs

**\`Host coverage (advisory, llvm-cov)\`**
- Runs \`cargo-llvm-cov\` against the existing host-test set (racsh, rpkg, rapt, init, racterm).
- Uploads the LCOV artifact for offline inspection.
- \`continue-on-error: true\` for one cycle, then flip to required.
- Kernel/libc-lite/userland coverage comes from QEMU smokes — they target \`x86_64-unknown-none\` so llvm-cov can't attach.

**\`cargo-audit (advisory)\`**
- Runs \`cargo-audit --deny unsound --deny unmaintained --deny notice\` against \`Cargo.lock\`.
- Catches RUSTSEC advisories on the two bootloader deps + any transitive bumps.
- \`continue-on-error: true\` for one cycle, then flip to required.

### PR hygiene

- Closed stale **PR #3** (\`[codex] fix CI toolchain action\`) as superseded — main already uses \`dtolnay/rust-toolchain@master\` with \`toolchain: nightly-2026-05-21\` as the input, exactly the pattern PR #3 proposed.

## Verification

\`\`\`
\$ bash scripts/check-unsafe-safety.sh --strict
scanned 456 unsafe blocks under kernel/ + libs/; 0 missing SAFETY
\$ echo \$?
0
\`\`\`

Pure documentation + CI YAML changes. No code touched.

## Follow-up plan

After this merges:
1. **rapt package layer** — the next epic, building on the existing \`pkg/rpkg\` MVP and the \`pkg/rapt\` skeleton. Wires repository fetching, dependency resolution, channel selection, and (once T4.1 crypto lands) signature verification.
2. **T4.1 crypto** — required for signed packages and TLS. Big epic on its own.
3. SMP scheduler refactor + RacTerm framebuffer renderer — deferred until the package layer stabilises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)